### PR TITLE
Add match scoring endpoint and clean schools data

### DIFF
--- a/backend/data/schools.csv
+++ b/backend/data/schools.csv
@@ -67,4 +67,3 @@ University of Connecticut,3.62,3.76,3.87,3.95,3.99,508,511,515,519,521
 New York Medical Colleges,3.57,3.73,3.86,3.95,3.99,512,515,517,519,521
 Michigan State University,3.38,3.62,3.84,3.95,3.99,502,504,509,514,518
 Loma Linda University ,3.67,3.82,3.92,3.96,3.99,502,507,512,516,519
-```

--- a/backend/index.mjs
+++ b/backend/index.mjs
@@ -7,6 +7,7 @@ import { JSONFile } from "lowdb/node";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { loadSchoolsCsv, searchSchools, findSchoolById } from "./services/schools.mjs";
+import { computeMatches, parseProfile } from "./services/match.mjs";
 
 const app = express();
 app.use(helmet());
@@ -89,6 +90,17 @@ app.get("/api/schools/:id", (req, res) => {
   const s = findSchoolById(schoolsData, id);
   if (!s) return res.status(404).json({ error: "not found" });
   res.json({ school: s });
+});
+
+app.post("/api/match", (req, res) => {
+  const profile = parseProfile(req.body?.profile ?? req.body ?? {});
+
+  if (!Number.isFinite(profile.gpa) && !Number.isFinite(profile.mcat)) {
+    return res.status(400).json({ error: "Provide a numeric gpa/cumGPA and/or mcat" });
+  }
+
+  const matches = computeMatches(profile, schoolsData.list, 30);
+  res.json({ matches });
 });
 
 const port = process.env.PORT || 4000;

--- a/backend/services/match.mjs
+++ b/backend/services/match.mjs
@@ -1,0 +1,76 @@
+const clamp = (val, min, max) => Math.min(Math.max(val, min), max);
+
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function parseProfile(raw) {
+  const gpa = toFiniteNumber(raw?.gpa ?? raw?.cumGPA);
+  const mcat = toFiniteNumber(raw?.mcat);
+  return { gpa, mcat };
+}
+
+export function percentileScore(value, cutoffs = []) {
+  if (!Number.isFinite(value)) return null;
+
+  const points = cutoffs
+    .filter((p) => Number.isFinite(p?.value) && Number.isFinite(p?.percentile))
+    .sort((a, b) => a.percentile - b.percentile);
+
+  if (points.length === 0) return null;
+
+  const first = points[0];
+  if (value <= first.value) {
+    if (first.value === 0) return clamp(first.percentile, 0, 100);
+    const scaled = (value / first.value) * first.percentile;
+    return clamp(scaled, 0, 100);
+  }
+
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (value <= curr.value) {
+      const range = curr.value - prev.value;
+      const ratio = range === 0 ? 0 : (value - prev.value) / range;
+      const pct = prev.percentile + ratio * (curr.percentile - prev.percentile);
+      return clamp(pct, 0, 100);
+    }
+  }
+
+  const last = points[points.length - 1];
+  const tailRange = last.value === 0 ? 0 : value - last.value;
+  const tailRatio = tailRange <= 0 || last.value === 0 ? 0 : tailRange / last.value;
+  const extrapolated = last.percentile + tailRatio * (100 - last.percentile);
+  return clamp(extrapolated, 0, 100);
+}
+
+export function scoreSchool(profile, school) {
+  const gpaScore = percentileScore(profile.gpa, school.gpaPercentiles);
+  const mcatScore = percentileScore(profile.mcat, school.mcatPercentiles);
+
+  const availableScores = [gpaScore, mcatScore].filter((n) => Number.isFinite(n));
+  if (availableScores.length === 0) return null;
+
+  const matchScore = availableScores.reduce((sum, n) => sum + n, 0) / availableScores.length;
+
+  return {
+    schoolId: school.schoolId,
+    name: school.name,
+    matchScore: Math.round(matchScore),
+    gpaScore: Number.isFinite(gpaScore) ? Math.round(gpaScore) : null,
+    mcatScore: Number.isFinite(mcatScore) ? Math.round(mcatScore) : null,
+    gpaMedian: school.gpa50 ?? null,
+    mcatMedian: school.mcat50 ?? null,
+  };
+}
+
+export function computeMatches(profile, schools, limit = 30) {
+  const matches = schools
+    .map((school) => scoreSchool(profile, school))
+    .filter((x) => x && Number.isFinite(x.matchScore))
+    .sort((a, b) => b.matchScore - a.matchScore)
+    .slice(0, limit);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add a `/api/match` endpoint that parses profile GPA/MCAT values and returns the top 30 scored schools
- parse percentile cutoffs for GPA/MCAT from the CSV so matching has complete data
- clean the schools CSV by removing the stray trailing markdown fence

## Testing
- node - <<'NODE'
import { loadSchoolsCsv } from './backend/services/schools.mjs';
import { computeMatches, parseProfile } from './backend/services/match.mjs';
const data = await loadSchoolsCsv(new URL('./backend/data/schools.csv', import.meta.url));
const profile = parseProfile({ gpa: '3.8', mcat: '520' });
const matches = computeMatches(profile, data.list, 3);
console.log(matches);
NODE

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694557a973248326ba4a9e8060661efb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add match scoring via `POST /api/match` using GPA/MCAT percentiles parsed from CSV, and clean the schools CSV.
> 
> - **Backend API**:
>   - Add `POST /api/match` that parses profile `gpa/cumGPA` and `mcat` and returns top 30 scored schools.
> - **Matching Logic**:
>   - Introduce `services/match.mjs` with profile parsing, percentile interpolation, per-school scoring, and top-N ranking.
> - **Data Loading**:
>   - Update `services/schools.mjs` to parse GPA/MCAT percentile columns and expose `gpaPercentiles`/`mcatPercentiles` plus medians (`gpa50`, `mcat50`).
> - **Data**:
>   - Clean `backend/data/schools.csv` by removing stray trailing markdown fence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5bdcaf1d314316587dc5654174bda4597e37950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->