### PR TITLE
Add storage for user demographics, experiences, and essays

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,3 +11,6 @@ npm run start
 API endpoints:
 POST /api/profile    -> save profile (JSON body)
 GET  /api/profile/:id -> fetch profile
+GET  /api/profile/user/:userId -> fetch latest profile for a user (plus history)
+
+Profile payload now supports demographics, experiences, and essays in addition to academics so user sessions can persist the full application context.

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -10,12 +10,34 @@ export interface MatchResult {
 
 export interface SubmittedProfilePayload {
   name: string;
+  userId?: string;
   undergrad?: string;
   major?: string;
   cumGPA?: string;
   scienceGPA?: string;
   mcat?: string;
   gradYear?: string;
-  experiences?: unknown[];
+  experiences?: Experience[];
+  demographics?: Demographics;
+  essays?: EssaysPayload;
   updatedAt?: string;
+}
+
+export interface Experience {
+  id: number | string;
+  type: string;
+  title?: string;
+  hours?: string;
+  description?: string;
+}
+
+export interface Demographics {
+  age?: string;
+  state?: string;
+  preferredRegions?: string[];
+  missionPreferences?: string[];
+}
+
+export interface EssaysPayload {
+  personalStatement?: string;
 }


### PR DESCRIPTION
## Summary
- expand the backend profile schema to persist demographics, essays, and experience details per user
- expose a helper endpoint to retrieve the most recent profile for a given user
- wire the profile intake form to collect demographics and essay content alongside experience data for saving

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a996f22883268bc586b8b2d31607)