### PR TITLE
Include user ID when requesting matches

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -70,7 +70,13 @@ export default function App() {
 
   async function fetchMatchesForProfile(profileId: string, ownerUserId?: string) {
     try {
-      const res = await fetch(`/api/match?profileId=${profileId}&limit=30`);
+      const params = new URLSearchParams({ profileId, limit: "30" });
+      const resolvedUserId = ownerUserId ?? session?.userId;
+      if (resolvedUserId) {
+        params.set("userId", resolvedUserId);
+      }
+
+      const res = await fetch(`/api/match?${params.toString()}`);
       if (!res.ok) {
         console.error("Failed to fetch matches", await res.text());
         return;

--- a/src/app/components/ProfileIntake.tsx
+++ b/src/app/components/ProfileIntake.tsx
@@ -156,7 +156,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       const matchRes = await fetch("/api/match", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId, profile: payload, limit: 30 }),
+        body: JSON.stringify({ profileId, profile: payload, limit: 30, userId: resolvedUserId }),
       });
 
       if (!matchRes.ok) {


### PR DESCRIPTION
## Summary
- send the user ID with match requests so saved profiles can be matched successfully
- ensure saved-profile match fetch uses query parameters built with the current session

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a1e9b5a4083268530d79fc469c644)