### PR TITLE
Deterministic match scoring: add demographics, state & extras to scoring

### DIFF
--- a/backend/index.mjs
+++ b/backend/index.mjs
@@ -36,6 +36,9 @@ const experienceSchema = z.object({
 const demographicsSchema = z.object({
   age: z.string().optional(),
   state: z.string().optional(),
+  race: z.string().optional(),
+  gender: z.string().optional(),
+  ses: z.string().optional(),
   preferredRegions: z.array(z.string()).optional(),
   missionPreferences: z.array(z.string()).optional(),
 });
@@ -54,6 +57,7 @@ const schema = z.object({
   mcat: z.string().optional(),
   gradYear: z.string().optional(),
   experiences: z.array(experienceSchema).optional(),
+  extrasScore: z.union([z.string(), z.number()]).optional(),
   demographics: demographicsSchema.optional(),
   essays: essaysSchema.optional(),
 });
@@ -203,7 +207,10 @@ app.get("/api/profile/user/:userId", requireAuth, async (req, res) => {
 // load schools data
 let schoolsData = { list: [], mapById: new Map(), mapByName: new Map() };
 try {
-  schoolsData = await loadSchoolsCsv(new URL("./data/schools.csv", import.meta.url));
+  schoolsData = await loadSchoolsCsv(
+    new URL("./data/schools.csv", import.meta.url),
+    new URL("./data/CSV_Data - DEMOGRAPHICS.csv", import.meta.url)
+  );
   console.log(`Loaded ${schoolsData.list.length} schools`);
 } catch (err) {
   console.warn("Could not load schools data:", err.message);

--- a/backend/services/match.mjs
+++ b/backend/services/match.mjs
@@ -1,65 +1,180 @@
 const clamp = (val, min, max) => Math.min(Math.max(val, min), max);
 
+const STATE_ABBREVIATIONS = {
+  al: "alabama",
+  ak: "alaska",
+  az: "arizona",
+  ar: "arkansas",
+  ca: "california",
+  co: "colorado",
+  ct: "connecticut",
+  de: "delaware",
+  fl: "florida",
+  ga: "georgia",
+  hi: "hawaii",
+  id: "idaho",
+  il: "illinois",
+  in: "indiana",
+  ia: "iowa",
+  ks: "kansas",
+  ky: "kentucky",
+  la: "louisiana",
+  me: "maine",
+  md: "maryland",
+  ma: "massachusetts",
+  mi: "michigan",
+  mn: "minnesota",
+  ms: "mississippi",
+  mo: "missouri",
+  mt: "montana",
+  ne: "nebraska",
+  nv: "nevada",
+  nh: "new hampshire",
+  nj: "new jersey",
+  nm: "new mexico",
+  ny: "new york",
+  nc: "north carolina",
+  nd: "north dakota",
+  oh: "ohio",
+  ok: "oklahoma",
+  or: "oregon",
+  pa: "pennsylvania",
+  ri: "rhode island",
+  sc: "south carolina",
+  sd: "south dakota",
+  tn: "tennessee",
+  tx: "texas",
+  ut: "utah",
+  vt: "vermont",
+  va: "virginia",
+  wa: "washington",
+  wv: "west virginia",
+  wi: "wisconsin",
+  wy: "wyoming",
+  dc: "district of columbia",
+};
+
+const UNDERREPRESENTED_RACES = [
+  "black",
+  "african american",
+  "hispanic",
+  "latino",
+  "latina",
+  "latinx",
+  "native american",
+  "american indian",
+  "alaska native",
+  "native hawaiian",
+  "pacific islander",
+];
+
 function toFiniteNumber(value) {
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
 }
 
-export function parseProfile(raw) {
-  const gpa = toFiniteNumber(raw?.gpa ?? raw?.cumGPA);
-  const mcat = toFiniteNumber(raw?.mcat);
-  return { gpa, mcat };
+function normalizeString(value) {
+  if (value === null || value === undefined) return "";
+  return value.toString().trim();
 }
 
-export function percentileScore(value, cutoffs = []) {
-  if (!Number.isFinite(value)) return null;
+function normalizeLower(value) {
+  return normalizeString(value).toLowerCase();
+}
 
-  const points = cutoffs
-    .filter((p) => Number.isFinite(p?.value) && Number.isFinite(p?.percentile))
-    .sort((a, b) => a.percentile - b.percentile);
+function normalizeState(value) {
+  const normalized = normalizeLower(value);
+  if (!normalized) return "";
+  return STATE_ABBREVIATIONS[normalized] ?? normalized;
+}
 
-  if (points.length === 0) return null;
+function percentileValue(points, percentile) {
+  return points?.find((p) => p.percentile === percentile)?.value ?? null;
+}
 
-  const first = points[0];
-  if (value <= first.value) {
-    if (first.value === 0) return clamp(first.percentile, 0, 100);
-    const scaled = (value / first.value) * first.percentile;
-    return clamp(scaled, 0, 100);
-  }
+function normalizedAcademicScore(value, p10, p90) {
+  if (!Number.isFinite(value) || !Number.isFinite(p10) || !Number.isFinite(p90)) return null;
+  const range = p90 - p10;
+  if (range <= 0) return null;
+  return clamp((value - p10) / range, 0, 1);
+}
 
-  for (let i = 1; i < points.length; i++) {
-    const prev = points[i - 1];
-    const curr = points[i];
-    if (value <= curr.value) {
-      const range = curr.value - prev.value;
-      const ratio = range === 0 ? 0 : (value - prev.value) / range;
-      const pct = prev.percentile + ratio * (curr.percentile - prev.percentile);
-      return clamp(pct, 0, 100);
-    }
-  }
+function isDisadvantaged(ses) {
+  return normalizeLower(ses).includes("disadvantaged");
+}
 
-  const last = points[points.length - 1];
-  const tailRange = last.value === 0 ? 0 : value - last.value;
-  const tailRatio = tailRange <= 0 || last.value === 0 ? 0 : tailRange / last.value;
-  const extrapolated = last.percentile + tailRatio * (100 - last.percentile);
-  return clamp(extrapolated, 0, 100);
+function isUnderrepresentedRace(race) {
+  const normalized = normalizeLower(race);
+  return UNDERREPRESENTED_RACES.some((entry) => normalized.includes(entry));
+}
+
+function schoolUrmPercent(school) {
+  const demo = school.demographics ?? {};
+  const values = [demo.raceHispanic, demo.raceBlack, demo.raceOther].filter((n) =>
+    Number.isFinite(n)
+  );
+  if (!values.length) return null;
+  return values.reduce((sum, n) => sum + n, 0);
+}
+
+export function parseProfile(raw) {
+  const demographics = raw?.demographics ?? {};
+  const gpa = toFiniteNumber(raw?.gpa ?? raw?.cumGPA);
+  const mcat = toFiniteNumber(raw?.mcat);
+  const extrasScore = toFiniteNumber(raw?.extrasScore ?? raw?.extras_score ?? demographics?.extrasScore);
+  return {
+    gpa,
+    mcat,
+    extrasScore,
+    state: demographics?.state ?? raw?.state ?? null,
+    race: demographics?.race ?? raw?.race ?? null,
+    gender: demographics?.gender ?? raw?.gender ?? null,
+    ses: demographics?.ses ?? raw?.ses ?? null,
+    preferredRegions: demographics?.preferredRegions ?? raw?.preferredRegions ?? [],
+  };
 }
 
 export function scoreSchool(profile, school) {
-  const gpaScore = percentileScore(profile.gpa, school.gpaPercentiles);
-  const mcatScore = percentileScore(profile.mcat, school.mcatPercentiles);
+  const gpaP10 = percentileValue(school.gpaPercentiles, 10);
+  const gpaP90 = percentileValue(school.gpaPercentiles, 90);
+  const mcatP10 = percentileValue(school.mcatPercentiles, 10);
+  const mcatP90 = percentileValue(school.mcatPercentiles, 90);
+
+  const gpaScore = normalizedAcademicScore(profile.gpa, gpaP10, gpaP90);
+  const mcatScore = normalizedAcademicScore(profile.mcat, mcatP10, mcatP90);
 
   const availableScores = [gpaScore, mcatScore].filter((n) => Number.isFinite(n));
   if (availableScores.length === 0) return null;
 
-  const matchScore = availableScores.reduce((sum, n) => sum + n, 0) / availableScores.length;
+  const profileState = normalizeState(profile.state);
+  const schoolState = normalizeState(school.state);
+
+  const stateBonus = school.isPublic && profileState && schoolState && profileState === schoolState ? 0.1 : 0;
+  const sesBonus = isDisadvantaged(profile.ses) ? 0.05 : 0;
+  const urmPercent = schoolUrmPercent(school);
+  const raceBonus =
+    isUnderrepresentedRace(profile.race) && Number.isFinite(urmPercent) && urmPercent >= 20 ? 0.05 : 0;
+  const extrasBonus = Number.isFinite(profile.extrasScore)
+    ? clamp(profile.extrasScore, 0, 100) / 100 * 0.05
+    : 0;
+
+  const matchScore = clamp(
+    (Number.isFinite(gpaScore) ? 0.4 * gpaScore : 0) +
+      (Number.isFinite(mcatScore) ? 0.4 * mcatScore : 0) +
+      stateBonus +
+      sesBonus +
+      raceBonus +
+      extrasBonus,
+    0,
+    1
+  );
 
   return {
     schoolId: school.schoolId,
     name: school.name,
-    matchScore: Math.round(matchScore),
-    gpaScore: Number.isFinite(gpaScore) ? Math.round(gpaScore) : null,
-    mcatScore: Number.isFinite(mcatScore) ? Math.round(mcatScore) : null,
+    matchScore: Math.round(matchScore * 100),
+    gpaScore: Number.isFinite(gpaScore) ? Math.round(gpaScore * 100) : null,
+    mcatScore: Number.isFinite(mcatScore) ? Math.round(mcatScore * 100) : null,
     gpaMedian: school.gpa50 ?? null,
     mcatMedian: school.mcat50 ?? null,
   };

--- a/backend/services/schools.mjs
+++ b/backend/services/schools.mjs
@@ -13,20 +13,34 @@ function toNumber(value) {
   return Number.isFinite(num) ? num : null;
 }
 
-export async function loadSchoolsCsv(fileUrl) {
+async function parseCsv(fileUrl) {
   const raw = await fs.readFile(fileUrl, "utf8");
   const lines = raw.split(/\r?\n/).filter(Boolean);
-  if (lines.length === 0) return { list: [], mapById: new Map(), mapByName: new Map() };
+  if (lines.length === 0) return { header: [], rows: [] };
 
   const header = lines[0].split(",").map(normalizeHeader);
-  const rows = lines.slice(1);
-
-  const list = rows.map((line, idx) => {
+  const rows = lines.slice(1).map((line) => {
     const cols = line.split(",");
     const obj = {};
     for (let i = 0; i < header.length; i++) {
       obj[header[i]] = (cols[i] || "").trim();
     }
+    return obj;
+  });
+
+  return { header, rows };
+}
+
+export async function loadSchoolsCsv(academicUrl, demographicsUrl) {
+  const academic = await parseCsv(academicUrl);
+  const demographics = demographicsUrl ? await parseCsv(demographicsUrl) : { rows: [] };
+
+  if (academic.rows.length === 0) {
+    return { list: [], mapById: new Map(), mapByName: new Map() };
+  }
+
+  const list = academic.rows.map((obj, idx) => {
+    const demo = demographics.rows[idx] ?? {};
 
     const schoolName = obj["school"] || obj["school name"] || obj["schoolname"] || `unknown-${idx}`;
     const schoolId = (obj["school"] || schoolName).toString().trim();
@@ -50,21 +64,47 @@ export async function loadSchoolsCsv(fileUrl) {
     const mcat50 = mcatPercentiles.find((p) => p.percentile === 50)?.value ?? 0;
     const gpa50 = gpaPercentiles.find((p) => p.percentile === 50)?.value ?? 0;
 
+    const publicPrivate = demo["public / private"] ?? "";
+    const publicFlag = publicPrivate.toString().trim().toLowerCase();
+
     const entry = {
       schoolId: schoolId,
       name: schoolName,
       normName: normalizeName(schoolName),
       raw: obj,
+      demographicsRaw: demo,
       mcat50,
       gpa50,
       gpaPercentiles,
       mcatPercentiles,
+      state: demo["state"] || null,
+      region: demo["region"] || null,
+      publicPrivate: publicPrivate || null,
+      isPublic: publicFlag.startsWith("public"),
+      demographics: {
+        degreeMd: toNumber(demo["d_degree_md"]),
+        degreeMdPhd: toNumber(demo["d_degree_md_phd"]),
+        degreeCombined: toNumber(demo["d_md_combined"]),
+        raceHispanic: toNumber(demo["d_hispanic"]),
+        raceBlack: toNumber(demo["d_black"]),
+        raceWhite: toNumber(demo["d_white"]),
+        raceAsian: toNumber(demo["d_asian"]),
+        raceOther: toNumber(demo["d_other"]),
+        genderMale: toNumber(demo["d_male"]),
+        genderFemale: toNumber(demo["d_female"]),
+        genderOther: toNumber(demo["d_gender_other"]),
+        sesNonDisadvantaged: toNumber(demo["ses_non_dis"]),
+        sesDisadvantaged: toNumber(demo["ses_disadvantaged"]),
+        totalApplicants: toNumber(demo["total_applicants"]),
+        applicantsInterviewed: toNumber(demo["applicants interviewed"]),
+        applicantsAccepted: toNumber(demo["applicants_accepted"]),
+      },
     };
 
     return entry;
   });
 
-  const mapById = new Map(list.map(s => [s.schoolId.toString().toLowerCase(), s]));
+  const mapById = new Map(list.map((s) => [s.schoolId.toString().toLowerCase(), s]));
   const mapByName = new Map();
   for (const s of list) {
     const key = s.normName;

--- a/src/app/components/ProfileIntake.tsx
+++ b/src/app/components/ProfileIntake.tsx
@@ -32,6 +32,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
   const [scienceGPA, setScienceGPA] = useState("3.72");
   const [mcat, setMcat] = useState("515");
   const [gradYear, setGradYear] = useState("2025");
+  const [extrasScore, setExtrasScore] = useState("");
   const [experiences, setExperiences] = useState<Experience[]>([{
     id: 1,
     type: "clinical",
@@ -53,6 +54,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     setScienceGPA(profile?.scienceGPA ?? "");
     setMcat(profile?.mcat ?? "");
     setGradYear(profile?.gradYear ?? "2025");
+    setExtrasScore(profile?.extrasScore !== undefined ? String(profile.extrasScore) : "");
     setExperiences(
       profile?.experiences?.length
         ? profile.experiences
@@ -71,12 +73,68 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       missionPreferences: profile?.demographics?.missionPreferences ?? [],
       age: profile?.demographics?.age,
       state: profile?.demographics?.state,
+      race: profile?.demographics?.race,
+      gender: profile?.demographics?.gender,
+      ses: profile?.demographics?.ses,
     });
     setPersonalStatement(profile?.essays?.personalStatement ?? "");
   }, [profile, defaultName]);
 
-  const preferredRegionOptions = ["West Coast", "East Coast", "Midwest", "South", "No Preference"];
+  const preferredRegionOptions = ["West", "Northeast", "Midwest", "South", "No Preference"];
   const missionPreferenceOptions = ["Research-Heavy", "Primary Care", "Rural Medicine", "Urban Health"];
+  const stateOptions = [
+    "Alabama",
+    "Alaska",
+    "Arizona",
+    "Arkansas",
+    "California",
+    "Colorado",
+    "Connecticut",
+    "Delaware",
+    "District of Columbia",
+    "Florida",
+    "Georgia",
+    "Hawaii",
+    "Idaho",
+    "Illinois",
+    "Indiana",
+    "Iowa",
+    "Kansas",
+    "Kentucky",
+    "Louisiana",
+    "Maine",
+    "Maryland",
+    "Massachusetts",
+    "Michigan",
+    "Minnesota",
+    "Mississippi",
+    "Missouri",
+    "Montana",
+    "Nebraska",
+    "Nevada",
+    "New Hampshire",
+    "New Jersey",
+    "New Mexico",
+    "New York",
+    "North Carolina",
+    "North Dakota",
+    "Ohio",
+    "Oklahoma",
+    "Oregon",
+    "Pennsylvania",
+    "Rhode Island",
+    "South Carolina",
+    "South Dakota",
+    "Tennessee",
+    "Texas",
+    "Utah",
+    "Vermont",
+    "Virginia",
+    "Washington",
+    "West Virginia",
+    "Wisconsin",
+    "Wyoming",
+  ];
 
   const addExperience = () => {
     setExperiences((prev) => [
@@ -116,6 +174,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     const mcat = (document.getElementById("mcat") as HTMLInputElement | null)?.value ?? "";
     const gradYear = "2025"; // current UI uses a custom Select component — keep default for now
 
+    const numericExtrasScore = Number.parseFloat(extrasScore);
     const payload: SubmittedProfilePayload = {
       name,
       userId: resolvedUserId,
@@ -126,6 +185,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       mcat,
       gradYear,
       experiences,
+      extrasScore: Number.isFinite(numericExtrasScore) ? numericExtrasScore : undefined,
       demographics,
       essays: {
         personalStatement,
@@ -410,6 +470,28 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
             </CardContent>
           </Card>
 
+          <Card>
+            <CardHeader>
+              <CardTitle>Experiences Strength</CardTitle>
+              <CardDescription>
+                Provide a 0-100 rating that reflects your research, clinical, leadership, and service depth.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Label htmlFor="extrasScore">Experiences score (0-100)</Label>
+              <Input
+                id="extrasScore"
+                name="extrasScore"
+                type="number"
+                min="0"
+                max="100"
+                placeholder="85"
+                value={extrasScore}
+                onChange={(e) => setExtrasScore(e.target.value)}
+              />
+            </CardContent>
+          </Card>
+
           {/* Summary Card */}
           <Card>
             <CardHeader>
@@ -469,17 +551,75 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
                       <SelectValue placeholder="Select state" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="ca">California</SelectItem>
-                      <SelectItem value="ny">New York</SelectItem>
-                      <SelectItem value="tx">Texas</SelectItem>
-                      <SelectItem value="fl">Florida</SelectItem>
+                      {stateOptions.map((state) => (
+                        <SelectItem key={state} value={state}>
+                          {state}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="race">Race/Ethnicity</Label>
+                  <Select
+                    value={demographics.race ?? undefined}
+                    onValueChange={(value) => setDemographics((prev) => ({ ...prev, race: value }))}
+                  >
+                    <SelectTrigger id="race">
+                      <SelectValue placeholder="Select race" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Black or African American">Black or African American</SelectItem>
+                      <SelectItem value="Hispanic/Latino">Hispanic/Latino</SelectItem>
+                      <SelectItem value="Native American or Alaska Native">Native American or Alaska Native</SelectItem>
+                      <SelectItem value="Native Hawaiian or Pacific Islander">Native Hawaiian or Pacific Islander</SelectItem>
+                      <SelectItem value="Asian">Asian</SelectItem>
+                      <SelectItem value="White">White</SelectItem>
+                      <SelectItem value="Other">Other</SelectItem>
+                      <SelectItem value="Prefer not to say">Prefer not to say</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="gender">Gender</Label>
+                  <Select
+                    value={demographics.gender ?? undefined}
+                    onValueChange={(value) => setDemographics((prev) => ({ ...prev, gender: value }))}
+                  >
+                    <SelectTrigger id="gender">
+                      <SelectValue placeholder="Select gender" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Female">Female</SelectItem>
+                      <SelectItem value="Male">Male</SelectItem>
+                      <SelectItem value="Non-binary">Non-binary</SelectItem>
+                      <SelectItem value="Prefer not to say">Prefer not to say</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ses">Socioeconomic Status</Label>
+                  <Select
+                    value={demographics.ses ?? undefined}
+                    onValueChange={(value) => setDemographics((prev) => ({ ...prev, ses: value }))}
+                  >
+                    <SelectTrigger id="ses">
+                      <SelectValue placeholder="Select SES" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Disadvantaged">Disadvantaged</SelectItem>
+                      <SelectItem value="Non-disadvantaged">Non-disadvantaged</SelectItem>
+                      <SelectItem value="Prefer not to say">Prefer not to say</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
               </div>
 
               <div className="space-y-2">
-                <Label>Preferred Geographic Regions</Label>
+                <Label>Geographic Preferences (Regions)</Label>
                 <div className="flex flex-wrap gap-2 mt-2">
                   {preferredRegionOptions.map((region) => {
                     const isActive = demographics.preferredRegions?.includes(region);
@@ -552,7 +692,6 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     </form>
   );
 }
-
 
 
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -18,6 +18,7 @@ export interface SubmittedProfilePayload {
   mcat?: string;
   gradYear?: string;
   experiences?: Experience[];
+  extrasScore?: number;
   demographics?: Demographics;
   essays?: EssaysPayload;
   updatedAt?: string;
@@ -34,6 +35,9 @@ export interface Experience {
 export interface Demographics {
   age?: string;
   state?: string;
+  race?: string;
+  gender?: string;
+  ses?: string;
   preferredRegions?: string[];
   missionPreferences?: string[];
 }


### PR DESCRIPTION
### Motivation
- Improve the school matching algorithm to be deterministic, explainable, and to account for demographic and geographic context alongside academic metrics.
- Allow the frontend to collect optional demographic fields and an experiences strength (`extrasScore`) so contextual bonuses can be applied.
- Use the provided paired CSVs (academic + demographics) to enrich school metadata for more realistic state/public and URM-aware scoring. 

### Description
- Load both academic and demographics CSVs in `loadSchoolsCsv` and attach `state`, `region`, `isPublic`, and parsed demographic percentages to each school record. 
- Replace percentile interpolation scoring with deterministic normalization using each school's P10/P90 for GPA and MCAT and compute weighted match using 40% GPA, 40% MCAT, plus capped bonuses for state (0.10), SES (0.05), race/URM (0.05) and experiences (`extrasScore`, up to 0.05) in `scoreSchool`/`normalizedAcademicScore`. 
- Expand `parseProfile` to surface `extrasScore`, `state`, `race`, `gender`, `ses`, and `preferredRegions` and update `types.ts` accordingly. 
- Add UI inputs in `ProfileIntake.tsx` to capture full `state` selection, `race`, `gender`, `ses`, and an `Experiences score (extrasScore)` so backend scoring can use these values. 

### Testing
- Started the dev stack via `npm run dev`, which loaded the schools dataset (68 schools) and reported the API running on `http://localhost:4000`, indicating CSV parsing succeeded. 
- Attempted an automated Playwright UI capture of the Demographics tab, but the run failed with `net::ERR_EMPTY_RESPONSE` while reaching the frontend; no UI screenshot was produced. 
- No unit tests or additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca9042a648326b64c9235fd72718c)