### PR TITLE
Add dynamic experience modeling, validation, “Other” type, and computed strength score

### DIFF
--- a/src/app/components/ProfileIntake.tsx
+++ b/src/app/components/ProfileIntake.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -32,19 +32,26 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
   const [scienceGPA, setScienceGPA] = useState("3.72");
   const [mcat, setMcat] = useState("515");
   const [gradYear, setGradYear] = useState("2025");
-  const [extrasScore, setExtrasScore] = useState("");
-  const [experiences, setExperiences] = useState<Experience[]>([{
-    id: 1,
-    type: "clinical",
-    title: "Emergency Room Volunteer",
-    hours: "150",
-    description: "Assisted nursing staff with patient transport and comfort measures...",
-  }]);
+  const [experiences, setExperiences] = useState<Experience[]>([]);
+  const [experienceErrors, setExperienceErrors] = useState<Record<string, Partial<Record<keyof Experience, string>>>>(
+    {}
+  );
+  const [newExperienceErrors, setNewExperienceErrors] = useState<Partial<Record<keyof Experience, string>>>({});
   const [demographics, setDemographics] = useState<Demographics>({
     preferredRegions: [],
     missionPreferences: [],
   });
   const [personalStatement, setPersonalStatement] = useState("");
+  const createExperienceId = () => (crypto.randomUUID ? crypto.randomUUID() : String(Date.now()));
+  const [newExperience, setNewExperience] = useState<Experience>(() => ({
+    id: createExperienceId(),
+    type: "Clinical Volunteering",
+    roleTitle: "",
+    totalHours: Number.NaN,
+    description: "",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }));
 
   useEffect(() => {
     setName(profile?.name ?? defaultName ?? "");
@@ -54,20 +61,28 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     setScienceGPA(profile?.scienceGPA ?? "");
     setMcat(profile?.mcat ?? "");
     setGradYear(profile?.gradYear ?? "2025");
-    setExtrasScore(profile?.extrasScore !== undefined ? String(profile.extrasScore) : "");
-    setExperiences(
-      profile?.experiences?.length
-        ? profile.experiences
-        : [
-            {
-              id: Date.now(),
-              type: "clinical",
-              title: "Emergency Room Volunteer",
-              hours: "150",
-              description: "Assisted nursing staff with patient transport and comfort measures...",
-            },
-          ],
-    );
+    const seedExperience: Experience = {
+      id: createExperienceId(),
+      type: "Clinical Volunteering",
+      roleTitle: "Emergency Room Volunteer",
+      totalHours: 150,
+      description: "Assisted nursing staff with patient transport and comfort measures...",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const normalizedExperiences = profile?.experiences?.length
+      ? profile.experiences.map((experience) => ({
+          id: experience.id ? String(experience.id) : createExperienceId(),
+          type: experience.type ?? "Clinical Volunteering",
+          roleTitle: experience.roleTitle ?? "",
+          totalHours:
+            typeof experience.totalHours === "number" ? experience.totalHours : Number.parseInt(String(experience.totalHours ?? ""), 10),
+          description: experience.description ?? "",
+          createdAt: experience.createdAt ?? new Date().toISOString(),
+          updatedAt: experience.updatedAt ?? new Date().toISOString(),
+        }))
+      : [seedExperience];
+    setExperiences(normalizedExperiences);
     setDemographics({
       preferredRegions: profile?.demographics?.preferredRegions ?? [],
       missionPreferences: profile?.demographics?.missionPreferences ?? [],
@@ -78,10 +93,28 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       ses: profile?.demographics?.ses,
     });
     setPersonalStatement(profile?.essays?.personalStatement ?? "");
+    setExperienceErrors({});
+    setNewExperienceErrors({});
+    setNewExperience({
+      id: createExperienceId(),
+      type: "Clinical Volunteering",
+      roleTitle: "",
+      totalHours: Number.NaN,
+      description: "",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
   }, [profile, defaultName]);
 
   const preferredRegionOptions = ["West", "Northeast", "Midwest", "South", "No Preference"];
   const missionPreferenceOptions = ["Research-Heavy", "Primary Care", "Rural Medicine", "Urban Health"];
+  const experienceTypeOptions = [
+    "Clinical Volunteering",
+    "Physician Shadowing",
+    "Research",
+    "Leadership",
+    "Community Service",
+  ];
   const stateOptions = [
     "Alabama",
     "Alaska",
@@ -136,20 +169,156 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     "Wyoming",
   ];
 
+  const resetNewExperience = () => {
+    setNewExperience({
+      id: createExperienceId(),
+      type: "Clinical Volunteering",
+      roleTitle: "",
+      totalHours: Number.NaN,
+      description: "",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  };
+
+  const validateExperience = (experience: Experience) => {
+    const errors: Partial<Record<keyof Experience, string>> = {};
+    const typeValue = experience.type?.trim();
+    if (!typeValue) {
+      errors.type = "Experience type is required.";
+    }
+    if (!experience.roleTitle?.trim()) {
+      errors.roleTitle = "Role/title is required.";
+    }
+    if (!Number.isInteger(experience.totalHours) || experience.totalHours <= 0) {
+      errors.totalHours = "Total hours must be a positive integer.";
+    }
+    if (!experience.description?.trim()) {
+      errors.description = "Description is required.";
+    } else if (experience.description.length > 700) {
+      errors.description = "Description must be 700 characters or less.";
+    }
+    return errors;
+  };
+
   const addExperience = () => {
+    const errors = validateExperience(newExperience);
+    if (Object.keys(errors).length > 0) {
+      setNewExperienceErrors(errors);
+      return;
+    }
     setExperiences((prev) => [
       ...prev,
-      { id: Date.now(), type: "clinical", title: "", hours: "", description: "" },
+      {
+        ...newExperience,
+        createdAt: newExperience.createdAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
     ]);
+    setNewExperienceErrors({});
+    resetNewExperience();
   };
 
   const removeExperience = (id: Experience["id"]) => {
+    setExperienceErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
     setExperiences((prev) => prev.filter((exp) => exp.id !== id));
   };
 
   const updateExperience = (id: Experience["id"], patch: Partial<Experience>) => {
-    setExperiences((prev) => prev.map((e) => (e.id === id ? { ...e, ...patch } : e)));
+    const updatedAt = new Date().toISOString();
+    let updatedExperience: Experience | null = null;
+    setExperiences((prev) =>
+      prev.map((experience) => {
+        if (experience.id !== id) {
+          return experience;
+        }
+        updatedExperience = { ...experience, ...patch, updatedAt };
+        return updatedExperience;
+      })
+    );
+    if (updatedExperience) {
+      setExperienceErrors((prev) => ({
+        ...prev,
+        [id]: validateExperience(updatedExperience),
+      }));
+    }
   };
+
+  const updateNewExperience = (patch: Partial<Experience>) => {
+    const updatedAt = new Date().toISOString();
+    setNewExperience((prev) => {
+      const updated = { ...prev, ...patch, updatedAt };
+      setNewExperienceErrors(validateExperience(updated));
+      return updated;
+    });
+  };
+
+  const experienceSummary = useMemo(() => {
+    return experiences.reduce(
+      (acc, experience) => {
+        const typeKey = experienceTypeOptions.includes(experience.type)
+          ? experience.type
+          : "Other";
+        const hours = Number.isFinite(experience.totalHours) ? experience.totalHours : 0;
+        switch (typeKey) {
+          case "Clinical Volunteering":
+            acc.clinical += hours;
+            break;
+          case "Research":
+            acc.research += hours;
+            break;
+          case "Physician Shadowing":
+            acc.shadowing += hours;
+            break;
+          case "Community Service":
+            acc.community += hours;
+            break;
+          case "Leadership":
+            acc.leadership += hours;
+            break;
+          default:
+            acc.other += hours;
+            break;
+        }
+        return acc;
+      },
+      {
+        clinical: 0,
+        research: 0,
+        shadowing: 0,
+        community: 0,
+        leadership: 0,
+        other: 0,
+      }
+    );
+  }, [experiences, experienceTypeOptions]);
+
+  const experienceScore = useMemo(() => {
+    const totals = Object.values(experienceSummary);
+    const totalHours = totals.reduce((sum, value) => sum + value, 0);
+    if (totalHours === 0) {
+      return 0;
+    }
+    const nonZeroCategories = totals.filter((value) => value > 0).length;
+    const maxShare = Math.max(...totals) / totalHours;
+
+    // Heuristic: reward total hours with diminishing returns, boost distribution + balance, penalize over-concentration.
+    const totalPoints = 50 * (1 - Math.exp(-totalHours / 250));
+    const distributionPoints = (nonZeroCategories / totals.length) * 30;
+    const balanceBonus =
+      experienceSummary.clinical > 0 &&
+      experienceSummary.community > 0 &&
+      experienceSummary.research > 0
+        ? 15
+        : 0;
+    const concentrationPenalty = maxShare > 0.6 ? (maxShare - 0.6) * 40 : 0;
+
+    return Math.min(100, Math.max(0, Math.round(totalPoints + distributionPoints + balanceBonus - concentrationPenalty)));
+  }, [experienceSummary]);
 
   const toggleDemographicArray = (field: "preferredRegions" | "missionPreferences", value: string) => {
     setDemographics((prev) => {
@@ -165,6 +334,26 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (experiences.length === 0) {
+      alert("Please add at least one experience before continuing.");
+      return;
+    }
+
+    const validationResults = experiences.reduce<Record<string, Partial<Record<keyof Experience, string>>>>(
+      (acc, experience) => {
+        const errors = validateExperience(experience);
+        if (Object.keys(errors).length > 0) {
+          acc[experience.id] = errors;
+        }
+        return acc;
+      },
+      {}
+    );
+
+    if (Object.keys(validationResults).length > 0) {
+      setExperienceErrors(validationResults);
+      return;
+    }
 
     // grab simple input values by id where native inputs exist
     const undergrad = (document.getElementById("undergrad") as HTMLInputElement | null)?.value ?? "UC Berkeley";
@@ -174,7 +363,6 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     const mcat = (document.getElementById("mcat") as HTMLInputElement | null)?.value ?? "";
     const gradYear = "2025"; // current UI uses a custom Select component — keep default for now
 
-    const numericExtrasScore = Number.parseFloat(extrasScore);
     const payload: SubmittedProfilePayload = {
       name,
       userId: resolvedUserId,
@@ -185,7 +373,7 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       mcat,
       gradYear,
       experiences,
-      extrasScore: Number.isFinite(numericExtrasScore) ? numericExtrasScore : undefined,
+      extrasScore: experienceScore,
       demographics,
       essays: {
         personalStatement,
@@ -397,6 +585,103 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
               </div>
             </CardHeader>
             <CardContent className="space-y-6">
+              <div className="p-4 border border-gray-200 rounded-lg space-y-4">
+                <div className="flex items-center justify-between">
+                  <Badge variant="outline">New Experience</Badge>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>Experience Type</Label>
+                    <Select
+                      value={experienceTypeOptions.includes(newExperience.type) ? newExperience.type : "Other"}
+                      onValueChange={(value) => {
+                        if (value === "Other") {
+                          updateNewExperience({
+                            type: experienceTypeOptions.includes(newExperience.type) ? "" : newExperience.type,
+                          });
+                        } else {
+                          updateNewExperience({ type: value });
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {experienceTypeOptions.map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {option}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value="Other">Other</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {newExperienceErrors.type && (
+                      <p className="text-xs text-red-600">{newExperienceErrors.type}</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Total Hours</Label>
+                    <Input
+                      type="number"
+                      placeholder="150"
+                      value={Number.isFinite(newExperience.totalHours) ? String(newExperience.totalHours) : ""}
+                      onChange={(e) => {
+                        const parsed = Number.parseInt(e.target.value, 10);
+                        updateNewExperience({ totalHours: Number.isNaN(parsed) ? Number.NaN : parsed });
+                      }}
+                    />
+                    {newExperienceErrors.totalHours && (
+                      <p className="text-xs text-red-600">{newExperienceErrors.totalHours}</p>
+                    )}
+                  </div>
+                </div>
+
+                {!experienceTypeOptions.includes(newExperience.type) && (
+                  <div className="space-y-2">
+                    <Label>Specify Experience Type</Label>
+                    <Input
+                      placeholder="e.g., Healthcare Startup Internship"
+                      value={newExperience.type}
+                      onChange={(e) => updateNewExperience({ type: e.target.value })}
+                    />
+                    {newExperienceErrors.type && (
+                      <p className="text-xs text-red-600">{newExperienceErrors.type}</p>
+                    )}
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label>Role/Title</Label>
+                  <Input
+                    placeholder="e.g., Emergency Room Volunteer"
+                    value={newExperience.roleTitle}
+                    onChange={(e) => updateNewExperience({ roleTitle: e.target.value })}
+                  />
+                  {newExperienceErrors.roleTitle && (
+                    <p className="text-xs text-red-600">{newExperienceErrors.roleTitle}</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Description (700 character limit - AMCAS format)</Label>
+                  <Textarea
+                    placeholder="Describe your responsibilities, skills learned, and impact..."
+                    maxLength={700}
+                    rows={4}
+                    value={newExperience.description}
+                    onChange={(e) => updateNewExperience({ description: e.target.value })}
+                  />
+                  <p className="text-xs text-gray-500">
+                    {newExperience.description.length}/700 characters
+                  </p>
+                  {newExperienceErrors.description && (
+                    <p className="text-xs text-red-600">{newExperienceErrors.description}</p>
+                  )}
+                </div>
+              </div>
+
               {experiences.map((exp, idx) => (
                 <div key={exp.id} className="p-4 border border-gray-200 rounded-lg space-y-4">
                   <div className="flex items-center justify-between">
@@ -417,39 +702,74 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
                     <div className="space-y-2">
                       <Label>Experience Type</Label>
                       <Select
-                        value={exp.type}
-                        onValueChange={(value) => updateExperience(exp.id, { type: value })}
+                        value={experienceTypeOptions.includes(exp.type) ? exp.type : "Other"}
+                        onValueChange={(value) => {
+                          if (value === "Other") {
+                            updateExperience(exp.id, {
+                              type: experienceTypeOptions.includes(exp.type) ? "" : exp.type,
+                            });
+                          } else {
+                            updateExperience(exp.id, { type: value });
+                          }
+                        }}
                       >
                         <SelectTrigger>
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="clinical">Clinical Volunteering</SelectItem>
-                          <SelectItem value="shadowing">Physician Shadowing</SelectItem>
-                          <SelectItem value="research">Research</SelectItem>
-                          <SelectItem value="leadership">Leadership</SelectItem>
-                          <SelectItem value="community">Community Service</SelectItem>
+                          {experienceTypeOptions.map((option) => (
+                            <SelectItem key={option} value={option}>
+                              {option}
+                            </SelectItem>
+                          ))}
+                          <SelectItem value="Other">Other</SelectItem>
                         </SelectContent>
                       </Select>
+                      {experienceErrors[exp.id]?.type && (
+                        <p className="text-xs text-red-600">{experienceErrors[exp.id]?.type}</p>
+                      )}
                     </div>
                     <div className="space-y-2">
                       <Label>Total Hours</Label>
                       <Input
                         type="number"
                         placeholder="150"
-                        value={exp.hours ?? ""}
-                        onChange={(e) => updateExperience(exp.id, { hours: e.target.value })}
+                        value={Number.isFinite(exp.totalHours) ? String(exp.totalHours) : ""}
+                        onChange={(e) => {
+                          const parsed = Number.parseInt(e.target.value, 10);
+                          updateExperience(exp.id, { totalHours: Number.isNaN(parsed) ? Number.NaN : parsed });
+                        }}
                       />
+                      {experienceErrors[exp.id]?.totalHours && (
+                        <p className="text-xs text-red-600">{experienceErrors[exp.id]?.totalHours}</p>
+                      )}
                     </div>
                   </div>
+
+                  {!experienceTypeOptions.includes(exp.type) && (
+                    <div className="space-y-2">
+                      <Label>Specify Experience Type</Label>
+                      <Input
+                        placeholder="e.g., Healthcare Startup Internship"
+                        value={exp.type}
+                        onChange={(e) => updateExperience(exp.id, { type: e.target.value })}
+                      />
+                      {experienceErrors[exp.id]?.type && (
+                        <p className="text-xs text-red-600">{experienceErrors[exp.id]?.type}</p>
+                      )}
+                    </div>
+                  )}
 
                   <div className="space-y-2">
                     <Label>Role/Title</Label>
                     <Input
                       placeholder="e.g., Emergency Room Volunteer"
-                      value={exp.title ?? ""}
-                      onChange={(e) => updateExperience(exp.id, { title: e.target.value })}
+                      value={exp.roleTitle}
+                      onChange={(e) => updateExperience(exp.id, { roleTitle: e.target.value })}
                     />
+                    {experienceErrors[exp.id]?.roleTitle && (
+                      <p className="text-xs text-red-600">{experienceErrors[exp.id]?.roleTitle}</p>
+                    )}
                   </div>
 
                   <div className="space-y-2">
@@ -458,12 +778,15 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
                       placeholder="Describe your responsibilities, skills learned, and impact..."
                       maxLength={700}
                       rows={4}
-                      value={exp.description ?? ""}
+                      value={exp.description}
                       onChange={(e) => updateExperience(exp.id, { description: e.target.value })}
                     />
                     <p className="text-xs text-gray-500">
-                      {(exp.description?.length ?? 0)}/700 characters
+                      {exp.description.length}/700 characters
                     </p>
+                    {experienceErrors[exp.id]?.description && (
+                      <p className="text-xs text-red-600">{experienceErrors[exp.id]?.description}</p>
+                    )}
                   </div>
                 </div>
               ))}
@@ -486,8 +809,8 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
                 min="0"
                 max="100"
                 placeholder="85"
-                value={extrasScore}
-                onChange={(e) => setExtrasScore(e.target.value)}
+                value={experienceScore}
+                readOnly
               />
             </CardContent>
           </Card>
@@ -498,23 +821,33 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
               <CardTitle>Experience Summary</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                 <div className="text-center p-4 bg-blue-50 rounded-lg">
-                  <p className="text-2xl font-semibold text-blue-700">150</p>
+                  <p className="text-2xl font-semibold text-blue-700">{experienceSummary.clinical}</p>
                   <p className="text-sm text-gray-600">Clinical Hours</p>
                 </div>
                 <div className="text-center p-4 bg-green-50 rounded-lg">
-                  <p className="text-2xl font-semibold text-green-700">200</p>
+                  <p className="text-2xl font-semibold text-green-700">{experienceSummary.research}</p>
                   <p className="text-sm text-gray-600">Research Hours</p>
                 </div>
                 <div className="text-center p-4 bg-purple-50 rounded-lg">
-                  <p className="text-2xl font-semibold text-purple-700">80</p>
+                  <p className="text-2xl font-semibold text-purple-700">{experienceSummary.shadowing}</p>
                   <p className="text-sm text-gray-600">Shadowing Hours</p>
                 </div>
                 <div className="text-center p-4 bg-orange-50 rounded-lg">
-                  <p className="text-2xl font-semibold text-orange-700">120</p>
+                  <p className="text-2xl font-semibold text-orange-700">{experienceSummary.community}</p>
                   <p className="text-sm text-gray-600">Community Service</p>
                 </div>
+                <div className="text-center p-4 bg-yellow-50 rounded-lg">
+                  <p className="text-2xl font-semibold text-yellow-700">{experienceSummary.leadership}</p>
+                  <p className="text-sm text-gray-600">Leadership Hours</p>
+                </div>
+                {experienceSummary.other > 0 && (
+                  <div className="text-center p-4 bg-teal-50 rounded-lg">
+                    <p className="text-2xl font-semibold text-teal-700">{experienceSummary.other}</p>
+                    <p className="text-sm text-gray-600">Other Hours</p>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -687,12 +1020,10 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
         <Button variant="outline" type="button" onClick={() => alert("Draft saved locally (not implemented)")}>
           Save Draft
         </Button>
-        <Button type="submit">Save & Continue to School Matching</Button>
+        <Button type="submit" disabled={experiences.length === 0}>
+          Save & Continue to School Matching
+        </Button>
       </div>
     </form>
   );
 }
-
-
-
-

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -25,11 +25,13 @@ export interface SubmittedProfilePayload {
 }
 
 export interface Experience {
-  id: number | string;
+  id: string;
   type: string;
-  title?: string;
-  hours?: string;
-  description?: string;
+  roleTitle: string;
+  totalHours: number;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface Demographics {


### PR DESCRIPTION
### Motivation
- Implement a correct, required-field experience data model and validation to prevent partial/draft experiences being saved.
- Add an `Other` experience option with a required custom label when selected so custom experience types are treated as first-class categories.
- Make the Experience Summary dynamic and derived from stored experiences so totals update on add/edit/delete.
- Replace the static extras score with a computed experiences strength score (0–100) that reflects hours, distribution, and balance.

### Description
- Reworked the core model by updating `Experience` in `src/app/types.ts` to the required schema with `id`, `type`, `roleTitle`, `totalHours`, `description`, `createdAt`, and `updatedAt`.
- Rewrote the experiences UX in `src/app/components/ProfileIntake.tsx` to use a controlled `newExperience` add flow, `validateExperience` logic, inline per-field error messages, and stable IDs via `crypto.randomUUID` (fallback to `Date.now`).
- Added `Other` handling: the dropdown includes `Other` and shows a required `Specify Experience Type` input when a custom type is chosen, and custom types are grouped under `Other` in the summary.
- Implemented reactive derived state: `experienceSummary` (category totals) and `experienceScore` (0–100 heuristic with diminishing returns, distribution reward, balance bonus, and concentration penalty) using `useMemo`, and disabled `Save & Continue` when no experiences exist.

### Testing
- Started the dev client with `npm run dev:client` to verify the app loads and the changes render successfully (dev server started successfully).
- Ran automated browser scripts (Playwright) to exercise the UI and capture screenshots; final runs produced screenshots (`after-continue.png`, `experiences.png`) showing the Experiences tab and summary (some earlier Playwright attempts timed out but the later captures succeeded).
- No unit test suite was present or executed as part of this change (no additional automated unit tests were added).
- Changes were smoke-tested manually via the dev server and committed (`Implement experience validation and summaries`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538c5f9c7083269eb4e8bb4a89308b)