### PR TITLE
Implement server-side Google OAuth, session cookies, and new auth/app layouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Backend (set in backend/.env or shell)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:4000/api/auth/google/callback
+FRONTEND_URL=http://localhost:5173
+SESSION_JWT_SECRET=replace-with-long-random-string
+DEV_AUTH=true
+
+# Frontend (Vite)
+VITE_API_BASE_URL=http://localhost:4000
+VITE_GOOGLE_CLIENT_ID=
+VITE_DEV_AUTH=true

--- a/README.md
+++ b/README.md
@@ -1,36 +1,42 @@
 # AI Med School Application Assistant
 
-  This is a code bundle for AI Med School Application Assistant.
+This is a code bundle for AI Med School Application Assistant.
 
-  ## Running the code
+## Running the code
 
-  Run `npm i` to install the dependencies.
+Run `npm i` to install the dependencies.
 
-  Run `npm run dev` to start the development server.
-  
-  1.Frontend (Terminal A)
+Run `npm run dev` to start the development server.
+
+1. Frontend (Terminal A)
+
 Start from the project root so Vite picks up vite.config.ts (proxy).
 
+```
 cd "/Users/aksharreddy/Downloads/AI Med School Application Assistant"
 npm install
 npm run dev
 # open http://localhost:5173
+```
 
 2. Backend (Terminal B)
+
+```
 cd "/Users/aksharreddy/Downloads/AI Med School Application Assistant/backend"
 npm install
-npm run start 
-
-npm run start   # or `npm run dev` to use nodemon
+npm run start
 # backend listens on http://localhost:4000 by default
-
+```
 
 ## Recommended: automatic dev launcher (avoids port conflicts)
+
 A launcher will find a free API port and start both the backend and the Vite dev server with the proper environment variables.
 
 From the project root run:
 
+```
 npm run dev:auto
+```
 
 What it does:
 - Picks an available port (tries 4000–4010, then an ephemeral port).
@@ -42,20 +48,57 @@ When to use:
 
 Alternative (manual) — two terminals
 - Terminal A (frontend):
+  ```
   cd "/Users/aksharreddy/Downloads/AI Med School Application Assistant"
   npm install
   npm run dev
+  ```
 
 - Terminal B (backend):
+  ```
   cd "/Users/aksharreddy/Downloads/AI Med School Application Assistant/backend"
   npm install
   PORT=4001 npm run start   # example: run backend on a different port
+  ```
 
 If you change the backend port manually, start the frontend with VITE_API_PORT set to match so Vite's proxy routes /api correctly:
 
+```
 VITE_API_PORT=4001 npm run dev
+```
 
 Troubleshooting
 - If you see ECONNREFUSED from Vite proxy, ensure the backend is running and listening on the port Vite expects (VITE_API_PORT or 4000).
 - To force-stop a process using a port:
+  ```
   lsof -ti:<port> | xargs -r kill
+  ```
+
+## Google OAuth setup (Authorization Code flow)
+
+Follow these steps to enable real Google sign-in.
+
+1) Create OAuth Consent Screen in Google Cloud Console.
+2) Create OAuth Client ID of type **Web application**.
+3) Authorized redirect URIs should include:
+   - `http://localhost:<BACKEND_PORT>/api/auth/google/callback`
+   - `https://<prod-domain>/api/auth/google/callback`
+4) Authorized JavaScript origins (optional for this flow) include:
+   - `http://localhost:<FRONTEND_PORT>`
+   - `https://<prod-domain>`
+5) Scopes: `openid`, `email`, `profile`.
+
+### Required environment variables
+
+Backend (`backend/.env` or environment):
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URI` (must exactly match Google Console)
+- `FRONTEND_URL` (e.g., `http://localhost:5173`)
+- `SESSION_JWT_SECRET` (random strong string)
+- `DEV_AUTH=true` (optional dev fallback when Google credentials are missing)
+
+Frontend (`.env` for Vite):
+- `VITE_API_BASE_URL` (e.g., `http://localhost:4000`)
+- `VITE_GOOGLE_CLIENT_ID` (optional, used only to toggle dev fallback UI)
+- `VITE_DEV_AUTH=true` (optional dev fallback UI in development)

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,17 +9,28 @@ npm install
 npm run start
 
 API endpoints:
-POST /api/profile    -> save profile (JSON body)
-GET  /api/profile/:id -> fetch profile
-GET  /api/profile/user/:userId -> fetch latest profile for a user (plus history)
+POST /api/profile    -> save profile (JSON body, requires session)
+GET  /api/profile/:id -> fetch profile (requires session)
+GET  /api/profile/user/:userId -> fetch latest profile for a user (requires session)
+
+Authentication (Google OAuth + session cookies)
+- Configure these backend environment variables:
+  - GOOGLE_CLIENT_ID
+  - GOOGLE_CLIENT_SECRET
+  - GOOGLE_REDIRECT_URI (e.g., http://localhost:4000/api/auth/google/callback)
+  - FRONTEND_URL (e.g., http://localhost:5173)
+  - SESSION_JWT_SECRET (random strong string)
+- OAuth endpoints:
+  - GET /api/auth/google/start
+  - GET /api/auth/google/callback
+  - GET /api/auth/me
+  - POST /api/auth/logout
+- Dev fallback (only when GOOGLE_* vars are missing AND DEV_AUTH=true or NODE_ENV=development):
+  - POST /api/auth/dev-login
 
 Profile payload now supports demographics, experiences, and essays in addition to academics so user sessions can persist the full application context.
 
-Authentication
-- Set `GOOGLE_CLIENT_ID` in the backend environment to enable Google ID token verification.
-- All profile endpoints require a valid `Authorization: Bearer <id_token>` header. Match endpoints require the token when resolving a stored profile ID and will reject requests if the stored profile belongs to a different user.
-
 Costs
-- Google Identity Services (the button + ID token issuance) is free; you are not billed per login.
+- Google OAuth (Authorization Code flow) is free; you are not billed per login.
 - Verifying Google ID tokens on the backend uses Google public keys and does not incur per-call charges.
 - The only potential costs come from your own hosting or if you choose a paid identity product (e.g., Firebase Auth with phone/MFA billing tiers).

--- a/backend/index.mjs
+++ b/backend/index.mjs
@@ -2,6 +2,7 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
+import cookieParser from "cookie-parser";
 import { Low } from "lowdb";
 import { JSONFile } from "lowdb/node";
 import { nanoid } from "nanoid";
@@ -9,13 +10,19 @@ import { z } from "zod";
 import { loadSchoolsCsv, searchSchools, findSchoolById } from "./services/schools.mjs";
 import { computeMatches, parseProfile } from "./services/match.mjs";
 import { OAuth2Client } from "google-auth-library";
+import jwt from "jsonwebtoken";
+import crypto from "crypto";
 
 const app = express();
 app.use(helmet());
+app.set("trust proxy", 1);
+app.use(cookieParser());
 app.use(express.json());
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:5173";
 app.use(
   cors({
-    origin: process.env.FRONTEND_ORIGIN || "http://localhost:5173",
+    origin: FRONTEND_URL,
+    credentials: true,
   })
 );
 app.use(
@@ -77,16 +84,36 @@ const schema = z.object({
 });
 
 const adapter = new JSONFile(new URL("./db.json", import.meta.url));
-const defaultData = { profiles: [] };
+const defaultData = { profiles: [], users: [] };
 const db = new Low(adapter, defaultData);
 await db.read();
 // ensure data is initialized
 db.data ||= defaultData;
+db.data.users ||= [];
+db.data.profiles ||= [];
 
 const DEFAULT_MATCH_LIMIT = 30;
 
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || process.env.VITE_GOOGLE_CLIENT_ID;
-const oauthClient = GOOGLE_CLIENT_ID ? new OAuth2Client(GOOGLE_CLIENT_ID) : null;
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI;
+const SESSION_JWT_SECRET = process.env.SESSION_JWT_SECRET || (process.env.NODE_ENV === "production" ? null : "dev-session-secret");
+const SESSION_COOKIE_NAME = "medadmit_session";
+const STATE_COOKIE_NAME = "medadmit_oauth_state";
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const isProd = process.env.NODE_ENV === "production";
+const oauthConfigured = Boolean(GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET && GOOGLE_REDIRECT_URI);
+const oauthClient = oauthConfigured ? new OAuth2Client(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI) : null;
+const baseCookieOptions = {
+  httpOnly: true,
+  secure: isProd,
+  sameSite: "lax",
+  path: "/",
+};
+
+if (!SESSION_JWT_SECRET) {
+  throw new Error("SESSION_JWT_SECRET must be set in production.");
+}
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "ENTER_API_KEY_HERE";
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.0-flash-001";
@@ -136,81 +163,210 @@ const essayAnalyzeSchema = z.object({
 });
 
 async function verifyGoogleIdToken(idToken) {
-  if (!oauthClient) {
-    throw new Error("Google auth is not configured (set GOOGLE_CLIENT_ID)");
+  if (!oauthClient || !GOOGLE_CLIENT_ID) {
+    throw new Error("Google OAuth is not configured");
   }
   const ticket = await oauthClient.verifyIdToken({ idToken, audience: GOOGLE_CLIENT_ID });
   const payload = ticket.getPayload();
   if (!payload?.sub) throw new Error("Invalid id token payload");
   return {
-    userId: payload.sub,
+    googleSub: payload.sub,
     email: payload.email,
     name: payload.name,
     picture: payload.picture,
   };
 }
 
-function resolveUserId(req) {
-  return (
-    req.headers["x-user-id"]?.toString() ||
-    req.body?.userId?.toString?.() ||
-    req.params?.userId?.toString?.() ||
-    req.query?.userId?.toString?.() ||
-    null
-  );
+function signSession(userId) {
+  return jwt.sign({ sub: userId }, SESSION_JWT_SECRET, { expiresIn: "7d" });
+}
+
+function setSessionCookie(res, userId) {
+  const token = signSession(userId);
+  res.cookie(SESSION_COOKIE_NAME, token, {
+    ...baseCookieOptions,
+    maxAge: SESSION_TTL_MS,
+  });
+}
+
+function clearSessionCookie(res) {
+  res.clearCookie(SESSION_COOKIE_NAME, baseCookieOptions);
+}
+
+function getSessionPayload(req) {
+  const token = req.cookies?.[SESSION_COOKIE_NAME];
+  if (!token) return null;
+  try {
+    return jwt.verify(token, SESSION_JWT_SECRET);
+  } catch (err) {
+    return null;
+  }
+}
+
+async function findUserById(userId) {
+  await db.read();
+  return db.data.users.find((user) => user.id === userId);
+}
+
+async function upsertGoogleUser({ googleSub, email, name, picture }) {
+  await db.read();
+  const now = new Date().toISOString();
+  let user = db.data.users.find((entry) => entry.googleSub === googleSub);
+  if (user) {
+    user.email = email ?? user.email;
+    user.name = name ?? user.name;
+    user.pictureUrl = picture ?? user.pictureUrl;
+    user.lastLoginAt = now;
+  } else {
+    user = {
+      id: nanoid(),
+      googleSub,
+      email,
+      name,
+      pictureUrl: picture,
+      authProvider: "google",
+      createdAt: now,
+      lastLoginAt: now,
+    };
+    db.data.users.push(user);
+  }
+  await db.write();
+  return user;
+}
+
+async function createDevUser({ name, email }) {
+  await db.read();
+  const now = new Date().toISOString();
+  const user = {
+    id: nanoid(),
+    googleSub: null,
+    email,
+    name,
+    pictureUrl: null,
+    authProvider: "dev",
+    createdAt: now,
+    lastLoginAt: now,
+  };
+  db.data.users.push(user);
+  await db.write();
+  return user;
 }
 
 async function requireAuth(req, res, next) {
-  const header = req.headers.authorization;
-
-  if (oauthClient && header?.startsWith("Bearer ")) {
-    const token = header.replace(/^Bearer\s+/i, "");
-    try {
-      const user = await verifyGoogleIdToken(token);
-      req.authUser = user;
-      req.userId = user.userId;
-    } catch (err) {
-      console.error("Auth failed", err.message);
-      return res.status(401).json({ error: "Invalid Google ID token" });
-    }
+  const session = getSessionPayload(req);
+  if (!session?.sub) {
+    return res.status(401).json({ error: "Authentication required" });
   }
-
-  if (!req.userId) {
-    const fallback = resolveUserId(req);
-    if (!fallback) return res.status(400).json({ error: "userId required" });
-    req.userId = fallback;
+  const user = await findUserById(session.sub);
+  if (!user) {
+    return res.status(401).json({ error: "Invalid session" });
   }
-
+  req.authUser = user;
+  req.userId = user.id;
   next();
 }
 
-async function attachAuthIfPresent(req, res, next) {
-  if (oauthClient) {
-    const header = req.headers.authorization;
-    if (header) {
-      if (!header.startsWith("Bearer ")) {
-        return res.status(401).json({ error: "Invalid Authorization header" });
-      }
-      try {
-        const user = await verifyGoogleIdToken(header.replace(/^Bearer\s+/i, ""));
-        req.authUser = user;
-        req.userId = user.userId;
-      } catch (err) {
-        console.error("Optional auth failed", err.message);
-        return res.status(401).json({ error: "Invalid Google ID token" });
-      }
-    }
+app.get("/api/auth/google/start", (req, res) => {
+  if (!oauthConfigured || !oauthClient) {
+    return res.status(500).json({ error: "Google OAuth is not configured" });
   }
 
-  if (!req.userId) {
-    const fallback = resolveUserId(req);
-    if (fallback) {
-      req.userId = fallback;
-    }
+  const state = crypto.randomBytes(32).toString("hex");
+  res.cookie(STATE_COOKIE_NAME, state, {
+    ...baseCookieOptions,
+    maxAge: 10 * 60 * 1000,
+  });
+
+  const authorizeUrl = oauthClient.generateAuthUrl({
+    access_type: "offline",
+    scope: ["openid", "email", "profile"],
+    prompt: "select_account",
+    state,
+  });
+
+  return res.redirect(authorizeUrl);
+});
+
+app.get("/api/auth/google/callback", async (req, res) => {
+  if (!oauthConfigured || !oauthClient) {
+    return res.status(500).json({ error: "Google OAuth is not configured" });
   }
 
-  next();
-}
+  const state = req.query.state?.toString();
+  const code = req.query.code?.toString();
+  const storedState = req.cookies?.[STATE_COOKIE_NAME];
+
+  if (!state || !storedState || state !== storedState) {
+    return res.status(400).json({ error: "Invalid OAuth state" });
+  }
+
+  if (!code) {
+    return res.status(400).json({ error: "Missing OAuth code" });
+  }
+
+  res.clearCookie(STATE_COOKIE_NAME, baseCookieOptions);
+
+  try {
+    const { tokens } = await oauthClient.getToken(code);
+    if (!tokens?.id_token) {
+      return res.status(400).json({ error: "Missing id_token from Google" });
+    }
+
+    const googleUser = await verifyGoogleIdToken(tokens.id_token);
+    const user = await upsertGoogleUser(googleUser);
+
+    setSessionCookie(res, user.id);
+    return res.redirect(`${FRONTEND_URL}/dashboard`);
+  } catch (err) {
+    console.error("OAuth callback failed", err);
+    return res.status(500).json({ error: "Google OAuth failed" });
+  }
+});
+
+app.get("/api/auth/me", async (req, res) => {
+  const session = getSessionPayload(req);
+  if (!session?.sub) {
+    return res.status(401).json({ error: "Not authenticated" });
+  }
+  const user = await findUserById(session.sub);
+  if (!user) {
+    return res.status(401).json({ error: "Invalid session" });
+  }
+  return res.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      pictureUrl: user.pictureUrl,
+    },
+  });
+});
+
+app.post("/api/auth/logout", (req, res) => {
+  clearSessionCookie(res);
+  return res.status(200).json({ ok: true });
+});
+
+app.post("/api/auth/dev-login", async (req, res) => {
+  const devFallbackEnabled =
+    (process.env.DEV_AUTH === "true" || process.env.NODE_ENV === "development") && !oauthConfigured;
+  if (!devFallbackEnabled) {
+    return res.status(404).json({ error: "Not found" });
+  }
+
+  const name = req.body?.name?.toString().trim() || "Dev User";
+  const email = req.body?.email?.toString().trim() || `dev-${nanoid(6)}@example.local`;
+  const user = await createDevUser({ name, email });
+  setSessionCookie(res, user.id);
+  return res.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      pictureUrl: user.pictureUrl,
+    },
+  });
+});
 
 function coerceLimit(rawLimit, fallback = DEFAULT_MATCH_LIMIT) {
   const limit = Number.parseInt(rawLimit ?? fallback, 10);
@@ -295,7 +451,7 @@ app.get("/api/schools/:id", (req, res) => {
   res.json({ school: s });
 });
 
-app.post("/api/match", attachAuthIfPresent, async (req, res) => {
+app.post("/api/match", requireAuth, async (req, res) => {
   const safeLimit = coerceLimit(req.body?.limit);
 
   let profileInput = req.body?.profile ?? req.body ?? {};
@@ -320,7 +476,7 @@ app.post("/api/match", attachAuthIfPresent, async (req, res) => {
   res.json({ matches });
 });
 
-app.get("/api/match", attachAuthIfPresent, async (req, res) => {
+app.get("/api/match", requireAuth, async (req, res) => {
   const safeLimit = coerceLimit(req.query.limit);
 
   let profileInput = {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,11 +8,13 @@
       "name": "ai-med-backend",
       "version": "0.0.1",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.0",
         "google-auth-library": "^10.5.0",
         "helmet": "^7.0.0",
+        "jsonwebtoken": "^9.0.2",
         "lowdb": "^6.0.1",
         "nanoid": "^5.1.6",
         "zod": "^3.23.2"
@@ -333,6 +335,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -1080,6 +1101,34 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -1100,6 +1149,48 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lowdb": {
       "version": "6.1.1",
@@ -1557,7 +1648,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,11 +7,13 @@
     "dev": "nodemon --watch ./index.mjs --exec node index.mjs"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-rate-limit": "^6.7.0",
     "google-auth-library": "^10.5.0",
     "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
     "lowdb": "^6.0.1",
     "nanoid": "^5.1.6",
     "zod": "^3.23.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-popper": "2.3.0",
         "react-resizable-panels": "2.1.7",
         "react-responsive-masonry": "2.7.1",
+        "react-router-dom": "^7.13.0",
         "react-slick": "0.31.0",
         "recharts": "2.15.2",
         "sonner": "2.0.3",
@@ -3689,6 +3690,19 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -5209,6 +5223,44 @@
       "integrity": "sha512-Q+u+nOH87PzjqGFd2PgTcmLpHPZnCmUPREHYoNBc8dwJv6fi51p9U6hqwG8g/T8MN86HrFjrU+uQU6yvETU7cA==",
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-slick": {
       "version": "0.31.0",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.31.0.tgz",
@@ -5461,6 +5513,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shell-quote": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-popper": "2.3.0",
     "react-resizable-panels": "2.1.7",
     "react-responsive-masonry": "2.7.1",
+    "react-router-dom": "^7.13.0",
     "react-slick": "0.31.0",
     "recharts": "2.15.2",
     "sonner": "2.0.3",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,332 +1,41 @@
-import { useEffect, useState } from "react";
-import { GraduationCap, User, Target, Calendar, LayoutDashboard, MessageSquare, FileText } from "lucide-react";
-import Dashboard from "./components/Dashboard";
-import ProfileIntake from "./components/ProfileIntake";
-import SchoolMatch from "./components/SchoolMatch";
-import ApplicationTracker from "./components/ApplicationTracker";
-import EssayReview from "./components/EssayReview";
-import { MatchResult, SubmittedProfilePayload } from "./types";
-import { Button } from "./components/ui/button";
-import { Input } from "./components/ui/input";
-
-type Page = "dashboard" | "profile" | "schools" | "tracker" | "essay" | "chat";
-
-type Session = {
-  mode: "guest" | "username" | "google";
-  userId: string;
-  displayName: string;
-};
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { AuthProvider } from "../auth/useAuth";
+import AppLayout from "./layouts/AppLayout";
+import AuthLayout from "./layouts/AuthLayout";
+import DashboardPage from "./pages/DashboardPage";
+import ProfilePage from "./pages/ProfilePage";
+import SchoolMatchPage from "./pages/SchoolMatchPage";
+import ApplicationTrackerPage from "./pages/ApplicationTrackerPage";
+import EssayReviewPage from "./pages/EssayReviewPage";
+import ChatPage from "./pages/ChatPage";
+import LoginPage from "./pages/LoginPage";
+import ProtectedRoute from "./routes/ProtectedRoute";
 
 export default function App() {
-  const [currentPage, setCurrentPage] = useState<Page>("dashboard");
-  const [matches, setMatches] = useState<MatchResult[]>([]);
-  const [profile, setProfile] = useState<(SubmittedProfilePayload & { id?: string }) | null>(null);
-  const [session, setSession] = useState<Session | null>(null);
-  const [authChoice, setAuthChoice] = useState<"guest" | "username" | "google">("guest");
-  const [usernameInput, setUsernameInput] = useState("");
-  const [googleEmailInput, setGoogleEmailInput] = useState("");
-
-  useEffect(() => {
-    const stored = localStorage.getItem("medadmit.session");
-    if (!stored) return;
-
-    try {
-      const parsed: Session = JSON.parse(stored);
-      setSession(parsed);
-    } catch (err) {
-      console.error("Failed to parse session", err);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!session) return;
-    localStorage.setItem("medadmit.session", JSON.stringify(session));
-    loadLatestProfile(session.userId);
-  }, [session]);
-
-  async function loadLatestProfile(userId: string) {
-    try {
-      const res = await fetch(`/api/profile/user/${userId}`);
-      if (!res.ok) return;
-
-      const data = await res.json();
-      const savedProfile = data.profile as SubmittedProfilePayload & { id?: string };
-      setProfile(savedProfile);
-
-      setSession((prev) => {
-        if (!prev) return prev;
-        const nextName = savedProfile.applicantProfile?.academic?.fullName ?? prev.displayName;
-        if (nextName === prev.displayName) return prev;
-        return { ...prev, displayName: nextName };
-      });
-
-      if (savedProfile?.id) {
-        await fetchMatchesForProfile(savedProfile.id, userId);
-      }
-    } catch (err) {
-      console.error("Failed to fetch latest profile", err);
-    }
-  }
-
-  async function fetchMatchesForProfile(profileId: string, ownerUserId?: string) {
-    try {
-      const params = new URLSearchParams({ profileId, limit: "30" });
-      const resolvedUserId = ownerUserId ?? session?.userId;
-      if (resolvedUserId) {
-        params.set("userId", resolvedUserId);
-      }
-
-      const res = await fetch(`/api/match?${params.toString()}`);
-      if (!res.ok) {
-        console.error("Failed to fetch matches", await res.text());
-        return;
-      }
-
-      const data = await res.json();
-      setMatches(data.matches ?? []);
-    } catch (err) {
-      console.error("Failed to fetch matches", err);
-    }
-  }
-
-  const navigation = [
-    { id: "dashboard", name: "Dashboard", icon: LayoutDashboard },
-    { id: "profile", name: "Your Profile", icon: User },
-    { id: "schools", name: "School Match", icon: Target },
-    { id: "tracker", name: "Application Tracker", icon: Calendar },
-    { id: "essay", name: "Essay Review", icon: FileText },
-    { id: "chat", name: "Chat Agent", icon: MessageSquare },
-  ];
-
-  const renderPage = () => {
-    switch (currentPage) {
-      case "dashboard":
-        return <Dashboard matches={matches} userName={defaultName} />;
-      case "profile":
-        return (
-          <ProfileIntake
-            userId={session.userId}
-            defaultName={defaultName}
-            onMatchesGenerated={(nextMatches) => {
-              setMatches(nextMatches);
-              setCurrentPage("schools");
-            }}
-            onProfileSaved={(savedProfile) => {
-              setProfile(savedProfile);
-              setSession((prev) =>
-                prev
-                  ? {
-                      ...prev,
-                      displayName: savedProfile.applicantProfile?.academic?.fullName ?? prev.displayName,
-                    }
-                  : prev,
-              );
-            }}
-          />
-        );
-      case "schools":
-        return <SchoolMatch matches={matches} />;
-      case "tracker":
-        return <ApplicationTracker />;
-      case "essay":
-        return <EssayReview />;
-      case "chat":
-        return (
-          <div className="flex items-center justify-center h-full">
-            <div className="text-center">
-              <MessageSquare className="w-16 h-16 mx-auto mb-4 text-blue-500" />
-              <h2 className="mb-2">Med School Chat Agent</h2>
-              <p className="text-gray-600">Coming soon - AI-powered admissions Q&A</p>
-            </div>
-          </div>
-        );
-      default:
-        return <Dashboard matches={matches} userName={defaultName} />;
-    }
-  };
-
-  const defaultName = profile?.applicantProfile?.academic?.fullName ?? session?.displayName;
-
-  const startGuestSession = () => {
-    const existing = localStorage.getItem("medadmit.guestId");
-    const guestId = existing ?? `guest-${crypto.randomUUID?.() ?? Date.now().toString(36)}`;
-    localStorage.setItem("medadmit.guestId", guestId);
-    activateSession({ mode: "guest", userId: guestId, displayName: "Guest" });
-  };
-
-  const activateSession = (next: Session) => {
-    setMatches([]);
-    setProfile(null);
-    setCurrentPage("dashboard");
-    setSession(next);
-  };
-
-  const handleUsernameLogin = () => {
-    if (!usernameInput.trim()) return;
-    const cleanedName = usernameInput.trim();
-    const slug = cleanedName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-    const userId = `user-${slug || Date.now().toString(36)}`;
-    activateSession({ mode: "username", userId, displayName: cleanedName });
-  };
-
-  const handleGoogleLogin = () => {
-    if (!googleEmailInput.trim()) return;
-    const email = googleEmailInput.trim().toLowerCase();
-    const nameFromEmail = email.split("@")[0] || "Google User";
-    const userId = `google-${email.replace(/[^a-z0-9]+/g, "-")}`;
-    activateSession({ mode: "google", userId, displayName: nameFromEmail });
-  };
-
-  if (!session) {
-    const googleConfigured = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID);
-
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
-        <div className="bg-white shadow-lg rounded-2xl p-8 w-full max-w-3xl space-y-6">
-          <div className="flex items-center gap-3">
-            <GraduationCap className="w-8 h-8 text-blue-600" />
-            <div>
-              <h1 className="text-2xl font-semibold">Welcome to MedAdmit AI</h1>
-              <p className="text-sm text-gray-600">Choose how you want to start. Your choice controls how we save your progress.</p>
-            </div>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-4">
-            <div
-              className={`border rounded-xl p-4 space-y-3 ${authChoice === "guest" ? "border-blue-500 bg-blue-50" : "border-gray-200"}`}
-            >
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium">Continue as Guest</h3>
-                <input
-                  type="radio"
-                  name="authChoice"
-                  value="guest"
-                  checked={authChoice === "guest"}
-                  onChange={() => setAuthChoice("guest")}
-                />
-              </div>
-              <p className="text-sm text-gray-600">Keep everything in this browser. No sign-in required.</p>
-              <Button className="w-full" variant={authChoice === "guest" ? "default" : "secondary"} onClick={startGuestSession}>
-                Continue
-              </Button>
-            </div>
-
-            <div
-              className={`border rounded-xl p-4 space-y-3 ${authChoice === "username" ? "border-blue-500 bg-blue-50" : "border-gray-200"}`}
-            >
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium">Sign in with a username</h3>
-                <input
-                  type="radio"
-                  name="authChoice"
-                  value="username"
-                  checked={authChoice === "username"}
-                  onChange={() => setAuthChoice("username")}
-                />
-              </div>
-              <p className="text-sm text-gray-600">Link your progress to a username so you can return to it later.</p>
-              <Input
-                placeholder="Enter a username"
-                value={usernameInput}
-                onChange={(e) => setUsernameInput(e.target.value)}
-                disabled={authChoice !== "username"}
-              />
-              <Button className="w-full" onClick={handleUsernameLogin} disabled={authChoice !== "username" || !usernameInput.trim()}>
-                Save & continue
-              </Button>
-            </div>
-
-            <div
-              className={`border rounded-xl p-4 space-y-3 ${authChoice === "google" ? "border-blue-500 bg-blue-50" : "border-gray-200"}`}
-            >
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium">Sign in with Google</h3>
-                <input
-                  type="radio"
-                  name="authChoice"
-                  value="google"
-                  checked={authChoice === "google"}
-                  onChange={() => setAuthChoice("google")}
-                />
-              </div>
-              <p className="text-sm text-gray-600">
-                Use your Google email to keep your profile linked. {googleConfigured ? "" : "Set VITE_GOOGLE_CLIENT_ID for full Google sign-in."}
-              </p>
-              <Input
-                type="email"
-                placeholder="you@example.com"
-                value={googleEmailInput}
-                onChange={(e) => setGoogleEmailInput(e.target.value)}
-                disabled={authChoice !== "google"}
-              />
-              <Button className="w-full" onClick={handleGoogleLogin} disabled={authChoice !== "google" || !googleEmailInput.trim()}>
-                Continue with Google
-              </Button>
-            </div>
-          </div>
-
-          <p className="text-xs text-gray-500">
-            You can switch methods later; each option saves data separately so you can try the app as a guest without touching your signed-in profile.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* Sidebar */}
-      <div className="w-64 bg-white border-r border-gray-200">
-        <div className="p-6">
-          <div className="flex items-center gap-2 mb-8">
-            <GraduationCap className="w-8 h-8 text-blue-600" />
-            <div>
-              <h1 className="font-semibold">MedAdmit AI</h1>
-              <p className="text-xs text-gray-500">Med School Assistant</p>
-            </div>
-          </div>
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route element={<AuthLayout />}>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<LoginPage />} />
+          </Route>
 
-          <nav className="space-y-1">
-            {navigation.map((item) => {
-              const Icon = item.icon;
-              const isActive = currentPage === item.id;
-              return (
-                <button
-                  key={item.id}
-                  onClick={() => setCurrentPage(item.id as Page)}
-                  className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
-                    isActive
-                      ? "bg-blue-50 text-blue-700"
-                      : "text-gray-700 hover:bg-gray-50"
-                  }`}
-                >
-                  <Icon className="w-5 h-5" />
-                  <span className="text-sm">{item.name}</span>
-                </button>
-              );
-            })}
-          </nav>
-        </div>
+          <Route element={<ProtectedRoute />}>
+            <Route element={<AppLayout />}>
+              <Route index element={<Navigate to="/dashboard" replace />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/profile" element={<ProfilePage />} />
+              <Route path="/schools" element={<SchoolMatchPage />} />
+              <Route path="/tracker" element={<ApplicationTrackerPage />} />
+              <Route path="/essay" element={<EssayReviewPage />} />
+              <Route path="/chat" element={<ChatPage />} />
+            </Route>
+          </Route>
 
-        <div className="absolute bottom-0 w-64 p-6 border-t border-gray-200">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
-              <User className="w-5 h-5 text-blue-600" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate">{defaultName || "Guest"}</p>
-              <p className="text-xs text-gray-500 truncate">
-                {session.mode === "guest" ? "Progress saved for this browser" : `Signed in as ${session.mode}`}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="max-w-7xl mx-auto p-8">{renderPage()}</div>
-      </div>
-    </div>
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }

--- a/src/app/components/EssayReview.tsx
+++ b/src/app/components/EssayReview.tsx
@@ -5,6 +5,7 @@ import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { Sparkles, AlertCircle, CheckCircle2, Lightbulb, FileText, ShieldAlert } from "lucide-react";
 import { Alert, AlertDescription } from "./ui/alert";
+import { apiUrl } from "../lib/api";
 
 type ParsedAnalysis = {
   overallImpression: string;
@@ -147,11 +148,12 @@ export default function EssayReview() {
     setAnalyzed(false);
 
     try {
-      const response = await fetch("/api/essay/analyze", {
+      const response = await fetch(apiUrl("/api/essay/analyze"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include",
         body: JSON.stringify({ essay: trimmedEssay }),
       });
 

--- a/src/app/components/ProfileIntake.tsx
+++ b/src/app/components/ProfileIntake.tsx
@@ -15,11 +15,11 @@ import {
   PreferNotToSay,
   SubmittedProfilePayload,
 } from "../types";
+import { apiUrl } from "../lib/api";
 
 interface ProfileIntakeProps {
   onMatchesGenerated?: (matches: MatchResult[]) => void;
   onProfileSaved?: (profile: SubmittedProfilePayload & { id?: string }) => void;
-  userId?: string;
   defaultName?: string;
   profile?: (SubmittedProfilePayload & { id?: string }) | null;
 }
@@ -53,8 +53,7 @@ type ApplicantProfileDraft = {
 
 const PREFER_NOT_TO_SAY: PreferNotToSay = "prefer_not_to_say";
 
-export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, userId, defaultName, profile }: ProfileIntakeProps) {
-  const resolvedUserId = userId ?? "demo-user";
+export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, defaultName, profile }: ProfileIntakeProps) {
   const [applicantProfile, setApplicantProfile] = useState<ApplicantProfileDraft>(() => ({
     academic: {
       fullName: defaultName ?? "",
@@ -572,7 +571,6 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
 
     // Persist the unified applicant profile as a single payload to avoid academic/demographic overwrite.
     const payload: SubmittedProfilePayload = {
-      userId: resolvedUserId,
       applicantProfile: normalized.profile,
       experiences,
       extrasScore: experienceScore,
@@ -583,9 +581,10 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
     };
 
     try {
-      const res = await fetch("/api/profile", {
+      const res = await fetch(apiUrl("/api/profile"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(payload),
       });
 
@@ -602,10 +601,11 @@ export default function ProfileIntake({ onMatchesGenerated, onProfileSaved, user
       const profileId: string | undefined = data.id;
       alert("Profile saved (id: " + (profileId ?? "unknown") + ")");
 
-      const matchRes = await fetch("/api/match", {
+      const matchRes = await fetch(apiUrl("/api/match"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId, profile: payload, limit: 30, userId: resolvedUserId }),
+        credentials: "include",
+        body: JSON.stringify({ profileId, profile: payload, limit: 30 }),
       });
 
       if (!matchRes.ok) {

--- a/src/app/layouts/AppLayout.tsx
+++ b/src/app/layouts/AppLayout.tsx
@@ -1,0 +1,102 @@
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { GraduationCap, LayoutDashboard, User, Target, Calendar, FileText, MessageSquare, LogOut } from "lucide-react";
+import { Button } from "../components/ui/button";
+import { useAuth } from "../../auth/useAuth";
+import { AppDataProvider, useAppData } from "../state/appData";
+
+const navigation = [
+  { name: "Dashboard", path: "/dashboard", icon: LayoutDashboard },
+  { name: "Your Profile", path: "/profile", icon: User },
+  { name: "School Match", path: "/schools", icon: Target },
+  { name: "Application Tracker", path: "/tracker", icon: Calendar },
+  { name: "Essay Review", path: "/essay", icon: FileText },
+  { name: "Chat Agent", path: "/chat", icon: MessageSquare },
+];
+
+function Sidebar() {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const { profile } = useAppData();
+
+  const displayName =
+    profile?.applicantProfile?.academic?.fullName || user?.name || user?.email || "Student";
+  const subtext = user?.email ? `Signed in as ${user.email}` : "Signed in";
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login");
+  };
+
+  return (
+    <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
+      <div className="p-6">
+        <div className="flex items-center gap-2 mb-8">
+          <GraduationCap className="w-8 h-8 text-blue-600" />
+          <div>
+            <h1 className="font-semibold">MedAdmit AI</h1>
+            <p className="text-xs text-gray-500">Med School Assistant</p>
+          </div>
+        </div>
+
+        <nav className="space-y-1">
+          {navigation.map((item) => {
+            const Icon = item.icon;
+            return (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                className={({ isActive }) =>
+                  `w-full flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
+                    isActive ? "bg-blue-50 text-blue-700" : "text-gray-700 hover:bg-gray-50"
+                  }`
+                }
+              >
+                <Icon className="w-5 h-5" />
+                <span className="text-sm">{item.name}</span>
+              </NavLink>
+            );
+          })}
+        </nav>
+      </div>
+
+      <div className="mt-auto p-6 border-t border-gray-200">
+        <div className="flex items-center gap-3 mb-4">
+          {user?.pictureUrl ? (
+            <img
+              src={user.pictureUrl}
+              alt={displayName}
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
+              <User className="w-5 h-5 text-blue-600" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{displayName}</p>
+            <p className="text-xs text-gray-500 truncate">{subtext}</p>
+          </div>
+        </div>
+        <Button variant="secondary" className="w-full" onClick={handleLogout}>
+          <LogOut className="w-4 h-4 mr-2" />
+          Sign out
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+export default function AppLayout() {
+  return (
+    <AppDataProvider>
+      <div className="flex min-h-screen bg-gray-50">
+        <Sidebar />
+        <main className="flex-1 overflow-auto">
+          <div className="max-w-7xl mx-auto p-8">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+    </AppDataProvider>
+  );
+}

--- a/src/app/layouts/AuthLayout.tsx
+++ b/src/app/layouts/AuthLayout.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from "react-router-dom";
+import { GraduationCap } from "lucide-react";
+
+export default function AuthLayout() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+      <div className="w-full max-w-md">
+        <div className="flex items-center gap-3 mb-6">
+          <GraduationCap className="w-9 h-9 text-blue-600" />
+          <div>
+            <h1 className="text-2xl font-semibold">MedAdmit AI</h1>
+            <p className="text-sm text-gray-600">Your personalized med school admissions coach.</p>
+          </div>
+        </div>
+        <div className="bg-white shadow-lg rounded-2xl p-6">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -1,0 +1,10 @@
+const rawBase = import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? "http://localhost:4000" : "");
+
+export const API_BASE = rawBase.replace(/\/$/, "");
+
+export function apiUrl(path: string) {
+  if (!path.startsWith("/")) {
+    return `${API_BASE}/${path}`;
+  }
+  return `${API_BASE}${path}`;
+}

--- a/src/app/pages/ApplicationTrackerPage.tsx
+++ b/src/app/pages/ApplicationTrackerPage.tsx
@@ -1,0 +1,5 @@
+import ApplicationTracker from "../components/ApplicationTracker";
+
+export default function ApplicationTrackerPage() {
+  return <ApplicationTracker />;
+}

--- a/src/app/pages/ChatPage.tsx
+++ b/src/app/pages/ChatPage.tsx
@@ -1,0 +1,13 @@
+import { MessageSquare } from "lucide-react";
+
+export default function ChatPage() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <div className="text-center">
+        <MessageSquare className="w-16 h-16 mx-auto mb-4 text-blue-500" />
+        <h2 className="mb-2">Med School Chat Agent</h2>
+        <p className="text-gray-600">Coming soon - AI-powered admissions Q&A</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -1,0 +1,11 @@
+import Dashboard from "../components/Dashboard";
+import { useAppData } from "../state/appData";
+import { useAuth } from "../../auth/useAuth";
+
+export default function DashboardPage() {
+  const { matches, profile } = useAppData();
+  const { user } = useAuth();
+  const userName = profile?.applicantProfile?.academic?.fullName || user?.name || user?.email || "Student";
+
+  return <Dashboard matches={matches} userName={userName} />;
+}

--- a/src/app/pages/EssayReviewPage.tsx
+++ b/src/app/pages/EssayReviewPage.tsx
@@ -1,0 +1,5 @@
+import EssayReview from "../components/EssayReview";
+
+export default function EssayReviewPage() {
+  return <EssayReview />;
+}

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { useAuth } from "../../auth/useAuth";
+import { apiUrl } from "../lib/api";
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const { user, loading, refresh } = useAuth();
+  const [devName, setDevName] = useState("Dev User");
+
+  const googleStartUrl = useMemo(() => apiUrl("/api/auth/google/start"), []);
+
+  const devFallbackEnabled =
+    import.meta.env.DEV &&
+    !import.meta.env.VITE_GOOGLE_CLIENT_ID &&
+    (import.meta.env.VITE_DEV_AUTH === "true" || import.meta.env.DEV);
+
+  useEffect(() => {
+    if (!loading && user) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [loading, user, navigate]);
+
+  const handleGoogleLogin = () => {
+    window.location.href = googleStartUrl;
+  };
+
+  const handleDevLogin = async () => {
+    try {
+      const response = await fetch(apiUrl("/api/auth/dev-login"), {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: devName }),
+      });
+      if (!response.ok) {
+        alert("Dev login failed. Configure Google OAuth credentials to continue.");
+        return;
+      }
+      await refresh();
+      navigate("/dashboard", { replace: true });
+    } catch (error) {
+      console.error("Dev login failed", error);
+      alert("Dev login failed. Check the backend console for details.");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Sign in to continue</h2>
+        <p className="text-sm text-gray-600">
+          Use your Google account to save your profile, track progress, and return anytime.
+        </p>
+      </div>
+
+      <Button className="w-full" onClick={handleGoogleLogin}>
+        Continue with Google
+      </Button>
+
+      {devFallbackEnabled ? (
+        <div className="border-t border-gray-200 pt-4 space-y-3">
+          <p className="text-xs text-gray-500">
+            Google OAuth is not configured. Use dev mode only for local testing.
+          </p>
+          <Input
+            value={devName}
+            onChange={(event) => setDevName(event.target.value)}
+            placeholder="Dev display name"
+          />
+          <Button variant="secondary" className="w-full" onClick={handleDevLogin}>
+            Continue in dev mode
+          </Button>
+        </div>
+      ) : null}
+
+      <p className="text-xs text-gray-500">
+        By continuing, you agree to our Terms of Service and Privacy Policy.
+      </p>
+    </div>
+  );
+}

--- a/src/app/pages/ProfilePage.tsx
+++ b/src/app/pages/ProfilePage.tsx
@@ -1,0 +1,22 @@
+import ProfileIntake from "../components/ProfileIntake";
+import { useAuth } from "../../auth/useAuth";
+import { useAppData } from "../state/appData";
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const { setMatches, profile, setProfile } = useAppData();
+  const defaultName = profile?.applicantProfile?.academic?.fullName || user?.name || user?.email || "";
+
+  return (
+    <ProfileIntake
+      defaultName={defaultName}
+      profile={profile}
+      onMatchesGenerated={(nextMatches) => {
+        setMatches(nextMatches);
+      }}
+      onProfileSaved={(savedProfile) => {
+        setProfile(savedProfile);
+      }}
+    />
+  );
+}

--- a/src/app/pages/SchoolMatchPage.tsx
+++ b/src/app/pages/SchoolMatchPage.tsx
@@ -1,0 +1,7 @@
+import SchoolMatch from "../components/SchoolMatch";
+import { useAppData } from "../state/appData";
+
+export default function SchoolMatchPage() {
+  const { matches } = useAppData();
+  return <SchoolMatch matches={matches} />;
+}

--- a/src/app/routes/ProtectedRoute.tsx
+++ b/src/app/routes/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../../auth/useAuth";
+
+export default function ProtectedRoute() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-gray-600">Loading your session...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/app/state/appData.tsx
+++ b/src/app/state/appData.tsx
@@ -1,0 +1,92 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { apiUrl } from "../lib/api";
+import { useAuth } from "../../auth/useAuth";
+import { MatchResult, SubmittedProfilePayload } from "../types";
+
+type ProfileRecord = SubmittedProfilePayload & { id?: string };
+
+type AppDataContextValue = {
+  matches: MatchResult[];
+  setMatches: React.Dispatch<React.SetStateAction<MatchResult[]>>;
+  profile: ProfileRecord | null;
+  setProfile: React.Dispatch<React.SetStateAction<ProfileRecord | null>>;
+  refreshProfile: () => Promise<void>;
+};
+
+const AppDataContext = createContext<AppDataContextValue | undefined>(undefined);
+
+export function AppDataProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const [matches, setMatches] = useState<MatchResult[]>([]);
+  const [profile, setProfile] = useState<ProfileRecord | null>(null);
+
+  const fetchMatchesForProfile = useCallback(
+    async (profileId: string) => {
+      try {
+        const params = new URLSearchParams({ profileId, limit: "30" });
+        const res = await fetch(apiUrl(`/api/match?${params.toString()}`), {
+          credentials: "include",
+        });
+        if (!res.ok) {
+          console.error("Failed to fetch matches", await res.text());
+          return;
+        }
+        const data = await res.json();
+        setMatches(data.matches ?? []);
+      } catch (err) {
+        console.error("Failed to fetch matches", err);
+      }
+    },
+    []
+  );
+
+  const refreshProfile = useCallback(async () => {
+    if (!user?.id) return;
+    try {
+      const res = await fetch(apiUrl(`/api/profile/user/${user.id}`), {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        return;
+      }
+      const data = await res.json();
+      const savedProfile = data.profile as ProfileRecord;
+      setProfile(savedProfile);
+      if (savedProfile?.id) {
+        await fetchMatchesForProfile(savedProfile.id);
+      }
+    } catch (err) {
+      console.error("Failed to fetch latest profile", err);
+    }
+  }, [user?.id, fetchMatchesForProfile]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      setProfile(null);
+      setMatches([]);
+      return;
+    }
+    refreshProfile();
+  }, [user?.id, refreshProfile]);
+
+  const value = useMemo(
+    () => ({
+      matches,
+      setMatches,
+      profile,
+      setProfile,
+      refreshProfile,
+    }),
+    [matches, profile, refreshProfile]
+  );
+
+  return <AppDataContext.Provider value={value}>{children}</AppDataContext.Provider>;
+}
+
+export function useAppData() {
+  const context = useContext(AppDataContext);
+  if (!context) {
+    throw new Error("useAppData must be used within AppDataProvider");
+  }
+  return context;
+}

--- a/src/auth/useAuth.tsx
+++ b/src/auth/useAuth.tsx
@@ -1,0 +1,82 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { apiUrl } from "../app/lib/api";
+
+export type AuthUser = {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  pictureUrl?: string | null;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  logout: () => Promise<void>;
+  setUser: (user: AuthUser | null) => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(apiUrl("/api/auth/me"), {
+        credentials: "include",
+      });
+      if (!response.ok) {
+        setUser(null);
+        return;
+      }
+      const data = await response.json();
+      setUser(data.user ?? null);
+    } catch (error) {
+      console.error("Failed to load session", error);
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await fetch(apiUrl("/api/auth/logout"), {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch (error) {
+      console.error("Logout failed", error);
+    } finally {
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      refresh,
+      logout,
+      setUser,
+    }),
+    [user, loading, refresh, logout]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
### Motivation
- Replace the insecure client-side Google ID token flow and localStorage sessions with a backend-owned OAuth 2.0 Authorization Code flow and server sessions to mirror real sites. 
- Prevent the login UI from rendering alongside the app shell by introducing distinct auth and app layouts and route protection so only one layout renders at a time. 
- Provide a safe dev-only fallback for local testing when Google credentials are not configured. 

### Description
- Backend: added full Authorization Code flow endpoints `GET /api/auth/google/start`, `GET /api/auth/google/callback`, `GET /api/auth/me`, `POST /api/auth/logout`, and a gated dev fallback `POST /api/auth/dev-login`; exchanges `code` server-side, verifies `id_token` with `google-auth-library`, upserts users in `lowdb`, and issues an HttpOnly signed session cookie (JWT) using `jsonwebtoken`; CSRF `state` is used and stored in an httpOnly cookie. 
- Backend: added cookie parsing, CORS with `credentials: true`, secure cookie options (secure in production), and minimal user persistence (`users` in `db.json`) and helper functions `setSessionCookie`, `clearSessionCookie`, `getSessionPayload`, `upsertGoogleUser`, and `createDevUser`. 
- Frontend: replaced the old mixed inline-login UI with proper routing using `react-router-dom` and two layouts: `AuthLayout` (centered card) for `/login` and `AppLayout` (sidebar + outlet) for protected routes; added `ProtectedRoute` to guard app routes. 
- Frontend: added `AuthProvider`/`useAuth` to fetch session from `GET /api/auth/me` using `credentials: "include"` and to expose `logout`, added `AppDataProvider` to load profile/matches, created `apiUrl` helper that reads `VITE_API_BASE_URL`, and updated calls (`/api/profile`, `/api/match`, `/api/essay/analyze`) to use credentialed requests and the new API helper. 
- UI: new `LoginPage` with a single `Continue with Google` button that redirects to `GET /api/auth/google/start`, optional dev-login UI gated by `import.meta.env.DEV && VITE_DEV_AUTH`, and sign-out hooked to `POST /api/auth/logout`. 
- Docs & config: added `.env.example` and README notes describing required Google Cloud setup and environment variables (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `FRONTEND_URL`, `SESSION_JWT_SECRET`, `VITE_API_BASE_URL`, `VITE_DEV_AUTH`). 

### Testing
- Installed dependencies and ran the dev launcher with `npm run dev` which started the backend and attempted to start the frontend; the backend successfully started and logged `Loaded 68 schools` and `API running on http://localhost:4000`. (backend start: success) 
- Fixed an initial build error caused by JSX in a `.ts` file by renaming `useAuth.ts` to `useAuth.tsx` and restarting; after that the Vite build step progressed normally (frontend build error: fixed). 
- Attempted an automated Playwright screenshot of `http://localhost:5173/login`, but the Playwright run failed (browser crash / `net::ERR_EMPTY_RESPONSE` or headless Chromium SIGSEGV) in this environment, so visual end-to-end capture could not be completed (playwright: failed). 
- No unit tests were present; main validation was running the dev server and confirming the backend OAuth endpoints and session cookie plumbing are in place (manual server smoke run: success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d1218e6fc8326834864fc0f3ebe16)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and authorization semantics end-to-end (new OAuth flow, cookie sessions, and tighter endpoint protection), which can easily break access control or user flows if misconfigured.
> 
> **Overview**
> Implements **server-owned authentication** by replacing the prior client/localStorage flow with Google OAuth2 Authorization Code login and an HttpOnly JWT session cookie.
> 
> Backend adds `/api/auth/google/start|callback`, `/api/auth/me`, `/api/auth/logout`, plus a gated `/api/auth/dev-login`, persists users in `lowdb`, enables CORS `credentials`, and makes key endpoints (notably `/api/profile` and `/api/match`) require a valid session.
> 
> Frontend switches to `react-router-dom` with separate `AuthLayout` vs `AppLayout`, adds `ProtectedRoute`, introduces `AuthProvider` + `AppDataProvider` for session/profile/match loading, and updates API calls to use `VITE_API_BASE_URL` + `credentials: "include"`; docs add `.env.example` and expanded OAuth setup instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7299a9213a636867f62c0758314b2904a73fcc73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->