### PR TITLE
Google OAuth loading problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ VITE_API_PORT=4001 npm run dev
 
 Troubleshooting
 - If you see ECONNREFUSED from Vite proxy, ensure the backend is running and listening on the port Vite expects (VITE_API_PORT or 4000).
+- Keep loopback hostnames consistent during OAuth. If `GOOGLE_REDIRECT_URI` uses `127.0.0.1`, use `127.0.0.1` for your frontend URL too (and vice versa for `localhost`) to avoid session cookies being written to one host alias and read from another.
 - To force-stop a process using a port:
   ```
   lsof -ti:<port> | xargs -r kill

--- a/backend/index.mjs
+++ b/backend/index.mjs
@@ -279,9 +279,50 @@ function shouldRedirectOAuthFailure(req) {
   return true;
 }
 
-function buildFrontendLoginRedirect(reason) {
+const LOCAL_LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function getHostnameFromHostHeader(hostHeader) {
+  if (!hostHeader) return null;
+  const value = hostHeader.toString().trim();
+  if (!value) return null;
+
+  if (value.startsWith("[")) {
+    const closingBracket = value.indexOf("]");
+    if (closingBracket > 1) {
+      return value.slice(1, closingBracket).toLowerCase();
+    }
+    return null;
+  }
+
+  const colonMatches = value.match(/:/g)?.length ?? 0;
+  if (colonMatches > 1) {
+    return value.toLowerCase();
+  }
+
+  const colonIndex = value.indexOf(":");
+  if (colonIndex === -1) {
+    return value.toLowerCase();
+  }
+
+  return value.slice(0, colonIndex).toLowerCase();
+}
+
+function alignFrontendLoopbackAlias(target, req) {
+  const frontendHost = target?.hostname?.toLowerCase();
+  const requestHost = getHostnameFromHostHeader(req?.get("host"));
+  if (!frontendHost || !requestHost) return;
+
+  const bothLoopback = LOCAL_LOOPBACK_HOSTS.has(frontendHost) && LOCAL_LOOPBACK_HOSTS.has(requestHost);
+  if (!bothLoopback || frontendHost === requestHost) return;
+
+  // Keep localhost/127.0.0.1 aliases aligned so session cookies remain usable after OAuth redirects.
+  target.hostname = requestHost;
+}
+
+function buildFrontendLoginRedirect(req, reason) {
   try {
     const target = new URL("/login", FRONTEND_URL);
+    alignFrontendLoopbackAlias(target, req);
     if (reason) {
       target.searchParams.set("authError", reason);
     }
@@ -292,9 +333,11 @@ function buildFrontendLoginRedirect(reason) {
   }
 }
 
-function buildFrontendAppRedirect(pathname = "/dashboard") {
+function buildFrontendAppRedirect(req, pathname = "/dashboard") {
   try {
-    return new URL(pathname, FRONTEND_URL).toString();
+    const target = new URL(pathname, FRONTEND_URL);
+    alignFrontendLoopbackAlias(target, req);
+    return target.toString();
   } catch {
     return `${FRONTEND_URL}${pathname}`;
   }
@@ -302,7 +345,7 @@ function buildFrontendAppRedirect(pathname = "/dashboard") {
 
 function respondOAuthFailure(req, res, { status = 500, error = "Google OAuth failed", reason = "oauth_failed" } = {}) {
   if (shouldRedirectOAuthFailure(req)) {
-    const location = buildFrontendLoginRedirect(reason);
+    const location = buildFrontendLoginRedirect(req, reason);
     oauthDebugLog("callback_frontend_redirect_on_error", {
       status,
       reason,
@@ -799,7 +842,7 @@ app.get("/api/auth/google/callback", async (req, res) => {
       throw sessionErr;
     }
 
-    const frontendRedirectUrl = buildFrontendAppRedirect("/dashboard");
+    const frontendRedirectUrl = buildFrontendAppRedirect(req, "/dashboard");
     oauthDebugLog("callback_success", {
       frontendRedirectUrl,
       hasUserId: Boolean(user?.id),


### PR DESCRIPTION
Fix Google OAuth session loss by preserving loopback hostname during redirects.

The issue occurred because the backend's post-OAuth redirect could switch between `localhost` and `127.0.0.1`, causing the session cookie (which is host-bound) to be lost, making the user appear unauthenticated despite successful Google consent. This PR ensures the redirect uses the same loopback hostname as the initial callback.

---
<p><a href="https://cursor.com/agents?id=bc-00401f4c-616b-438b-9c6b-abd350ee3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00401f4c-616b-438b-9c6b-abd350ee3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

